### PR TITLE
Improve SOTIF analysis dialogs

### DIFF
--- a/AutoSafeguard.py
+++ b/AutoSafeguard.py
@@ -2514,6 +2514,11 @@ class FaultTreeApp:
         self.comment_target = None
         self.versions = []
         self.diff_nodes = []
+        self.fi2tc_entries = []
+        self.tc2fi_entries = []
+        self.scenario_libraries = []
+        self.odd_elements = []
+
         # Provide the drawing helper to dialogs that may be opened later
         self.fta_drawing_helper = fta_drawing_helper
 
@@ -2549,6 +2554,10 @@ class FaultTreeApp:
         edit_menu.add_command(label="Add Robustness", command=lambda: self.add_node_of_type("Robustness Score"), accelerator="Ctrl+Shift+R")
         edit_menu.add_command(label="Add Gate", command=lambda: self.add_node_of_type("GATE"), accelerator="Ctrl+Shift+G")
         edit_menu.add_command(label="Add Basic Event", command=lambda: self.add_node_of_type("Basic Event"), accelerator="Ctrl+Shift+B")
+
+        edit_menu.add_command(label="Add Triggering Condition", command=lambda: self.add_node_of_type("Triggering Condition"))
+        edit_menu.add_command(label="Add Functional Insufficiency", command=lambda: self.add_node_of_type("Functional Insufficiency"))
+
         edit_menu.add_command(label="Add FMEA/FMEDA Event", command=self.add_basic_event_from_fmea)
         edit_menu.add_command(label="Edit Selected", command=self.edit_selected)
         edit_menu.add_command(label="Remove Connection", command=lambda: self.remove_connection(self.selected_node) if self.selected_node else None)
@@ -2598,6 +2607,17 @@ class FaultTreeApp:
         reliability_menu.add_command(label="FMEDA Analysis", command=self.open_fmeda_window)
         reliability_menu.add_command(label="FMEDA Manager", command=self.show_fmeda_list)
         menubar.add_cascade(label="Reliability", menu=reliability_menu)
+        sotif_menu = tk.Menu(menubar, tearoff=0)
+        sotif_menu.add_command(label="Triggering Conditions", command=self.show_triggering_condition_list)
+        sotif_menu.add_command(label="Functional Insufficiencies", command=self.show_functional_insufficiency_list)
+        sotif_menu.add_separator()
+        sotif_menu.add_command(label="FI2TC Analysis", command=self.open_fi2tc_window)
+        sotif_menu.add_command(label="TC2FI Analysis", command=self.open_tc2fi_window)
+        sotif_menu.add_separator()
+        sotif_menu.add_command(label="Scenario Libraries", command=self.manage_scenario_libraries)
+        sotif_menu.add_command(label="Import ODD Table", command=self.import_odd_table)
+        menubar.add_cascade(label="SOTIF", menu=sotif_menu)
+
         root.config(menu=menubar)
         root.bind("<Control-n>", lambda event: self.new_model())
         root.bind("<Control-s>", lambda event: self.save_model())
@@ -2616,6 +2636,9 @@ class FaultTreeApp:
         root.bind("<Control-Shift-r>", lambda event: self.add_node_of_type("Robustness Score"))
         root.bind("<Control-Shift-g>", lambda event: self.add_node_of_type("GATE"))
         root.bind("<Control-Shift-b>", lambda event: self.add_node_of_type("Basic Event"))
+        root.bind("<Control-Shift-t>", lambda event: self.add_node_of_type("Triggering Condition"))
+        root.bind("<Control-Shift-f>", lambda event: self.add_node_of_type("Functional Insufficiency"))
+
         root.bind("<Control-c>", lambda event: self.copy_node())
         root.bind("<Control-x>", lambda event: self.cut_node())
         root.bind("<Control-v>", lambda event: self.paste_node())
@@ -7685,6 +7708,39 @@ class FaultTreeApp:
     def get_all_basic_events(self):
         """Return a list of all basic events across all top-level trees."""
         return [n for n in self.get_all_nodes_in_model() if n.node_type.upper() == "BASIC EVENT"]
+    def get_all_triggering_conditions(self):
+        """Return all triggering condition nodes."""
+        return [n for n in self.get_all_nodes_in_model() if n.node_type.upper() == "TRIGGERING CONDITION"]
+
+    def get_all_functional_insufficiencies(self):
+        """Return all functional insufficiency nodes."""
+        return [n for n in self.get_all_nodes_in_model() if n.node_type.upper() == "FUNCTIONAL INSUFFICIENCY"]
+
+    def get_all_scenario_names(self):
+        """Return the list of scenario names from all scenario libraries."""
+        names = []
+        for lib in self.scenario_libraries:
+            for sc in lib.get("scenarios", []):
+                if isinstance(sc, dict):
+                    name = sc.get("name", "")
+                else:
+                    name = sc
+                if name:
+                    names.append(name)
+        return names
+
+    def get_all_scenery_names(self):
+        """Return the list of scenery/ODD element names."""
+        names = []
+        for el in self.odd_elements:
+            if isinstance(el, dict):
+                name = el.get("name") or el.get("element") or el.get("id")
+            else:
+                name = str(el)
+            if name:
+                names.append(name)
+        return names
+
 
     def get_all_failure_modes(self):
         """Return list of all failure mode nodes from FTA, FMEAs and FMEDAs."""
@@ -8128,6 +8184,10 @@ class FaultTreeApp:
         elif event_type.upper() == "BASIC EVENT":
             new_node = FaultTreeNode("", "Basic Event", parent=parent_node)
             new_node.failure_prob = 0.0
+        elif event_type.upper() == "TRIGGERING CONDITION":
+            new_node = FaultTreeNode("", "Triggering Condition", parent=parent_node)
+        elif event_type.upper() == "FUNCTIONAL INSUFFICIENCY":
+            new_node = FaultTreeNode("", "Functional Insufficiency", parent=parent_node)
         else:
             new_node = FaultTreeNode("", event_type, parent=parent_node)
         new_node.x = parent_node.x + 100
@@ -8574,6 +8634,44 @@ class FaultTreeApp:
         ttk.Button(btn_frame, text="Open", command=open_selected).pack(fill=tk.X)
         ttk.Button(btn_frame, text="Add", command=add_fmeda).pack(fill=tk.X)
         ttk.Button(btn_frame, text="Delete", command=delete_fmeda).pack(fill=tk.X)
+    def show_triggering_condition_list(self):
+        win = tk.Toplevel(self.root)
+        win.title("Triggering Conditions")
+        lb = tk.Listbox(win, height=10, width=40)
+        lb.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+        for tc in self.get_all_triggering_conditions():
+            lb.insert(tk.END, tc.user_name or f"TC {tc.unique_id}")
+        def export_csv():
+            path = filedialog.asksaveasfilename(defaultextension=".csv", filetypes=[("CSV","*.csv")])
+            if not path:
+                return
+            with open(path, "w", newline="") as f:
+                w = csv.writer(f)
+                w.writerow(["ID","Name","Description"])
+                for n in self.get_all_triggering_conditions():
+                    w.writerow([n.unique_id, n.user_name, n.description])
+            messagebox.showinfo("Export","Triggering conditions exported.")
+        ttk.Button(win, text="Export CSV", command=export_csv).pack(side=tk.RIGHT, padx=5, pady=5)
+
+    def show_functional_insufficiency_list(self):
+        win = tk.Toplevel(self.root)
+        win.title("Functional Insufficiencies")
+        lb = tk.Listbox(win, height=10, width=40)
+        lb.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+        for fi in self.get_all_functional_insufficiencies():
+            lb.insert(tk.END, fi.user_name or f"FI {fi.unique_id}")
+        def export_csv():
+            path = filedialog.asksaveasfilename(defaultextension=".csv", filetypes=[("CSV","*.csv")])
+            if not path:
+                return
+            with open(path, "w", newline="") as f:
+                w = csv.writer(f)
+                w.writerow(["ID","Name","Description"])
+                for n in self.get_all_functional_insufficiencies():
+                    w.writerow([n.unique_id, n.user_name, n.description])
+            messagebox.showinfo("Export","Functional insufficiencies exported.")
+        ttk.Button(win, text="Export CSV", command=export_csv).pack(side=tk.RIGHT, padx=5, pady=5)
+
 
     class FMEARowDialog(simpledialog.Dialog):
         def __init__(self, parent, node, app, fmea_entries, mechanisms=None, hide_diagnostics=False):
@@ -10233,6 +10331,33 @@ class FaultTreeApp:
         lib_lb.bind("<<ListboxSelect>>", refresh_mechs)
         refresh_libs()
 
+    def manage_scenario_libraries(self):
+        win = tk.Toplevel(self.root)
+        win.title("Scenario Libraries")
+        lb = tk.Listbox(win, height=8, width=40)
+        lb.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+        for lib in self.scenario_libraries:
+            lb.insert(tk.END, lib.get("name",""))
+        def add_lib():
+            name = simpledialog.askstring("New Library","Library name:")
+            if name:
+                self.scenario_libraries.append({"name":name,"scenarios":[]})
+                lb.insert(tk.END,name)
+        def delete_lib():
+            sel = lb.curselection()
+            if sel:
+                idx=sel[0]; del self.scenario_libraries[idx]; lb.delete(idx)
+        btn = ttk.Frame(win); btn.pack(side=tk.RIGHT, fill=tk.Y)
+        ttk.Button(btn,text="Add",command=add_lib).pack(fill=tk.X)
+        ttk.Button(btn,text="Delete",command=delete_lib).pack(fill=tk.X)
+
+    def import_odd_table(self):
+        path = filedialog.askopenfilename(filetypes=[("CSV","*.csv")])
+        if not path: return
+        with open(path,newline="") as f:
+            reader=csv.DictReader(f); self.odd_elements=list(reader)
+        messagebox.showinfo("Import","ODD table imported")
+
 
     def open_reliability_window(self):
         if hasattr(self, "_rel_window") and self._rel_window.winfo_exists():
@@ -10248,6 +10373,19 @@ class FaultTreeApp:
             self._hazop_window.lift()
             return
         self._hazop_window = self.HazopWindow(self)
+
+    def open_fi2tc_window(self):
+        if hasattr(self, "_fi2tc_window") and self._fi2tc_window.winfo_exists():
+            self._fi2tc_window.lift()
+            return
+        self._fi2tc_window = self.FI2TCWindow(self)
+
+    def open_tc2fi_window(self):
+        if hasattr(self, "_tc2fi_window") and self._tc2fi_window.winfo_exists():
+            self._tc2fi_window.lift()
+            return
+        self._tc2fi_window = self.TC2FIWindow(self)
+
     class ReliabilityWindow(tk.Toplevel):
         def __init__(self, app):
             super().__init__(app.root)
@@ -10598,6 +10736,115 @@ class FaultTreeApp:
             self.app.reliability_analyses.append(ra)
             messagebox.showinfo("Save", "Analysis saved")
 
+
+    class FI2TCWindow(tk.Toplevel):
+        COLS = [
+            "id","system_function","allocation","interfaces","insufficiency",
+            "scene","scenario","driver_behavior","occurrence","vehicle_effect",
+            "severity","design_measures","verification","measure_effectiveness",
+            "triggering_condition","worst_case","tc_effect","mitigation","acceptance"
+        ]
+        def __init__(self, app):
+            super().__init__(app.root)
+            self.app = app
+            self.title("FI2TC Analysis")
+            self.tree = ttk.Treeview(self, columns=self.COLS, show="headings")
+            for c in self.COLS:
+                self.tree.heading(c, text=c.replace("_"," ").title())
+                self.tree.column(c, width=120)
+            self.tree.pack(fill=tk.BOTH, expand=True)
+            btn = ttk.Frame(self)
+            btn.pack()
+            ttk.Button(btn, text="Add", command=self.add_row).pack(side=tk.LEFT, padx=2, pady=2)
+            ttk.Button(btn, text="Edit", command=self.edit_row).pack(side=tk.LEFT, padx=2, pady=2)
+            ttk.Button(btn, text="Delete", command=self.del_row).pack(side=tk.LEFT, padx=2, pady=2)
+            ttk.Button(btn, text="Export CSV", command=self.export_csv).pack(side=tk.LEFT, padx=2, pady=2)
+            self.refresh()
+
+        def refresh(self):
+            self.tree.delete(*self.tree.get_children())
+            for row in self.app.fi2tc_entries:
+                self.tree.insert("", "end", values=[row.get(k, "") for k in self.COLS])
+
+        class RowDialog(simpledialog.Dialog):
+            def __init__(self, parent, app, data=None):
+                self.app = app
+                self.parent_win = parent
+                default = {k: "" for k in parent.COLS}
+                self.data = data or default
+                super().__init__(parent, title="Edit Row")
+            def body(self, master):
+                fi_names = [n.user_name or f"FI {n.unique_id}" for n in self.app.get_all_functional_insufficiencies()]
+                tc_names = [n.user_name or f"TC {n.unique_id}" for n in self.app.get_all_triggering_conditions()]
+                scenario_names = self.app.get_all_scenario_names()
+                scene_names = self.app.get_all_scenery_names()
+                self.widgets = {}
+                r = 0
+                for col in self.parent_win.COLS:
+                    ttk.Label(master, text=col.replace("_"," ").title()).grid(row=r, column=0, sticky="e")
+                    if col == "triggering_condition":
+                        var = tk.StringVar(value=self.data.get(col, ""))
+                        cb = ttk.Combobox(master, textvariable=var, values=tc_names, state="readonly")
+                        cb.grid(row=r, column=1)
+                        self.widgets[col] = var
+                    elif col == "insufficiency":
+                        var = tk.StringVar(value=self.data.get(col, ""))
+                        cb = ttk.Combobox(master, textvariable=var, values=fi_names, state="readonly")
+                        cb.grid(row=r, column=1)
+                        self.widgets[col] = var
+                    elif col == "scenario":
+                        var = tk.StringVar(value=self.data.get(col, ""))
+                        cb = ttk.Combobox(master, textvariable=var, values=scenario_names, state="readonly")
+                        cb.grid(row=r, column=1)
+                        self.widgets[col] = var
+                    elif col == "scene":
+                        var = tk.StringVar(value=self.data.get(col, ""))
+                        cb = ttk.Combobox(master, textvariable=var, values=scene_names, state="readonly")
+                        cb.grid(row=r, column=1)
+                        self.widgets[col] = var
+                    else:
+                        ent = tk.Entry(master)
+                        ent.insert(0, self.data.get(col, ""))
+                        ent.grid(row=r, column=1)
+                        self.widgets[col] = ent
+                    r += 1
+            def apply(self):
+                for col, widget in self.widgets.items():
+                    if isinstance(widget, tk.Entry):
+                        self.data[col] = widget.get()
+                    else:
+                        self.data[col] = widget.get()
+
+        def add_row(self):
+            dlg = self.RowDialog(self, self.app)
+            self.app.fi2tc_entries.append(dlg.data)
+            self.refresh()
+        def edit_row(self):
+            sel = self.tree.focus()
+            if not sel:
+                return
+            idx = self.tree.index(sel)
+            data = self.app.fi2tc_entries[idx]
+            dlg = self.RowDialog(self, self.app, data)
+            self.refresh()
+        def del_row(self):
+            sel = self.tree.selection()
+            for iid in sel:
+                idx = self.tree.index(iid)
+                if idx < len(self.app.fi2tc_entries):
+                    del self.app.fi2tc_entries[idx]
+            self.refresh()
+        def export_csv(self):
+            path = filedialog.asksaveasfilename(defaultextension=".csv", filetypes=[("CSV","*.csv")])
+            if not path:
+                return
+            with open(path, "w", newline="") as f:
+                w = csv.writer(f)
+                w.writerow(self.COLS)
+                for r in self.app.fi2tc_entries:
+                    w.writerow([r.get(k, "") for k in self.COLS])
+            messagebox.showinfo("Export", "FI2TC exported")
+
     class HazopWindow(tk.Toplevel):
         def __init__(self, app):
             super().__init__(app.root)
@@ -10736,6 +10983,127 @@ class FaultTreeApp:
             )
             self.app.reliability_analyses.append(ra)
             messagebox.showinfo("Save", "Analysis saved")
+
+
+    class TC2FIWindow(tk.Toplevel):
+        COLS = [
+            "id",
+            "hazard_use_case",
+            "occurrence",
+            "system_function",
+            "elements_impacted",
+            "interfaces",
+            "functional_insufficiency",
+            "vehicle_effect",
+            "severity",
+            "design_measures",
+            "verification",
+            "measure_effectiveness",
+            "scene",
+            "scenario",
+            "driver_behavior",
+            "triggering_condition",
+            "tc_effect",
+            "mitigation",
+            "acceptance",
+        ]
+        def __init__(self, app):
+            super().__init__(app.root)
+            self.app = app
+            self.title("TC2FI Analysis")
+            self.tree = ttk.Treeview(self, columns=self.COLS, show="headings")
+            for c in self.COLS:
+                self.tree.heading(c, text=c.replace("_"," ").title())
+                self.tree.column(c, width=120)
+            self.tree.pack(fill=tk.BOTH, expand=True)
+            btn = ttk.Frame(self)
+            btn.pack()
+            ttk.Button(btn, text="Add", command=self.add_row).pack(side=tk.LEFT, padx=2, pady=2)
+            ttk.Button(btn, text="Edit", command=self.edit_row).pack(side=tk.LEFT, padx=2, pady=2)
+            ttk.Button(btn, text="Delete", command=self.del_row).pack(side=tk.LEFT, padx=2, pady=2)
+            ttk.Button(btn, text="Export CSV", command=self.export_csv).pack(side=tk.LEFT, padx=2, pady=2)
+            self.refresh()
+        def refresh(self):
+            self.tree.delete(*self.tree.get_children())
+            for row in self.app.tc2fi_entries:
+                self.tree.insert("", "end", values=[row.get(k, "") for k in self.COLS])
+        class RowDialog(simpledialog.Dialog):
+            def __init__(self, parent, app, data=None):
+                self.app = app
+                self.parent_win = parent
+                default = {k: "" for k in parent.COLS}
+                self.data = data or default
+                super().__init__(parent, title="Edit Row")
+            def body(self, master):
+                tc_names = [n.user_name or f"TC {n.unique_id}" for n in self.app.get_all_triggering_conditions()]
+                fi_names = [n.user_name or f"FI {n.unique_id}" for n in self.app.get_all_functional_insufficiencies()]
+                scenario_names = self.app.get_all_scenario_names()
+                scene_names = self.app.get_all_scenery_names()
+                self.widgets = {}
+                r = 0
+                for col in self.parent_win.COLS:
+                    ttk.Label(master, text=col.replace("_"," ").title()).grid(row=r, column=0, sticky="e")
+                    if col == "functional_insufficiency":
+                        var = tk.StringVar(value=self.data.get(col, ""))
+                        cb = ttk.Combobox(master, textvariable=var, values=fi_names, state="readonly")
+                        cb.grid(row=r, column=1)
+                        self.widgets[col] = var
+                    elif col == "triggering_condition":
+                        var = tk.StringVar(value=self.data.get(col, ""))
+                        cb = ttk.Combobox(master, textvariable=var, values=tc_names, state="readonly")
+                        cb.grid(row=r, column=1)
+                        self.widgets[col] = var
+                    elif col == "scenario":
+                        var = tk.StringVar(value=self.data.get(col, ""))
+                        cb = ttk.Combobox(master, textvariable=var, values=scenario_names, state="readonly")
+                        cb.grid(row=r, column=1)
+                        self.widgets[col] = var
+                    elif col == "scene":
+                        var = tk.StringVar(value=self.data.get(col, ""))
+                        cb = ttk.Combobox(master, textvariable=var, values=scene_names, state="readonly")
+                        cb.grid(row=r, column=1)
+                        self.widgets[col] = var
+                    else:
+                        ent = tk.Entry(master)
+                        ent.insert(0, self.data.get(col, ""))
+                        ent.grid(row=r, column=1)
+                        self.widgets[col] = ent
+                    r += 1
+            def apply(self):
+                for col, widget in self.widgets.items():
+                    if isinstance(widget, tk.Entry):
+                        self.data[col] = widget.get()
+                    else:
+                        self.data[col] = widget.get()
+        def add_row(self):
+            dlg = self.RowDialog(self, self.app)
+            self.app.tc2fi_entries.append(dlg.data)
+            self.refresh()
+        def edit_row(self):
+            sel = self.tree.focus()
+            if not sel:
+                return
+            idx = self.tree.index(sel)
+            data = self.app.tc2fi_entries[idx]
+            dlg = self.RowDialog(self, self.app, data)
+            self.refresh()
+        def del_row(self):
+            sel = self.tree.selection()
+            for iid in sel:
+                idx = self.tree.index(iid)
+                if idx < len(self.app.tc2fi_entries):
+                    del self.app.tc2fi_entries[idx]
+            self.refresh()
+        def export_csv(self):
+            path = filedialog.asksaveasfilename(defaultextension=".csv", filetypes=[("CSV","*.csv")])
+            if not path:
+                return
+            with open(path, "w", newline="") as f:
+                w = csv.writer(f)
+                w.writerow(self.COLS)
+                for r in self.app.tc2fi_entries:
+                    w.writerow([r.get(k, "") for k in self.COLS])
+            messagebox.showinfo("Export", "TC2FI exported")
 
     def copy_node(self):
         if self.selected_node and self.selected_node != self.root_node:
@@ -11116,6 +11484,10 @@ class FaultTreeApp:
                 for ra in self.reliability_analyses
             ],
             "hazop_entries": [asdict(e) for e in self.hazop_entries],
+            "fi2tc_entries": self.fi2tc_entries,
+            "tc2fi_entries": self.tc2fi_entries,
+            "scenario_libraries": self.scenario_libraries,
+            "odd_elements": self.odd_elements,
             "project_properties": self.project_properties,
             "global_requirements": global_requirements,
             "reviews": reviews,
@@ -11254,7 +11626,10 @@ class FaultTreeApp:
             )
 
         self.hazop_entries = [HazopEntry(**h) for h in data.get("hazop_entries", [])]
-
+        self.fi2tc_entries = data.get("fi2tc_entries", [])
+        self.tc2fi_entries = data.get("tc2fi_entries", [])
+        self.scenario_libraries = data.get("scenario_libraries", [])
+        self.odd_elements = data.get("odd_elements", [])
 
         self.fmedas = []
         for doc in data.get("fmedas", []):
@@ -12392,6 +12767,9 @@ class PageDiagram:
         menu.add_command(label="Add Robustness", command=lambda: self.context_add("Robustness Score"))
         menu.add_command(label="Add Gate", command=lambda: self.context_add("GATE"))
         menu.add_command(label="Add Basic Event", command=lambda: self.context_add("Basic Event"))
+        menu.add_command(label="Add Triggering Condition", command=lambda: self.context_add("Triggering Condition"))
+        menu.add_command(label="Add Functional Insufficiency", command=lambda: self.context_add("Functional Insufficiency"))
+
         menu.tk_popup(event.x_root, event.y_root)
 
     def context_edit(self, node):


### PR DESCRIPTION
## Summary
- add helpers to list scenario and scenery names
- populate FI2TC and TC2FI row dialogs with scenario and scene combo boxes

## Testing
- `python3 -m py_compile AutoSafeguard.py`

------
https://chatgpt.com/codex/tasks/task_b_68805ac6e1ac8325920d94bed5e206e5