### PR TITLE
Add hazard menu and persist HARA

### DIFF
--- a/AutoSafeguard.py
+++ b/AutoSafeguard.py
@@ -1418,6 +1418,10 @@ class FaultTreeApp:
         reliability_menu.add_command(label="FMEDA Analysis", command=self.open_fmeda_window)
         reliability_menu.add_command(label="FMEDA Manager", command=self.show_fmeda_list)
         menubar.add_cascade(label="Reliability", menu=reliability_menu)
+        hazard_menu = tk.Menu(menubar, tearoff=0)
+        hazard_menu.add_command(label="HAZOP Analysis", command=self.open_hazop_window)
+        hazard_menu.add_command(label="HARA Analysis", command=self.open_hara_window)
+        menubar.add_cascade(label="Hazard", menu=hazard_menu)
         sotif_menu = tk.Menu(menubar, tearoff=0)
         sotif_menu.add_command(label="Triggering Conditions", command=self.show_triggering_condition_list)
         sotif_menu.add_command(label="Functional Insufficiencies", command=self.show_functional_insufficiency_list)
@@ -9592,6 +9596,7 @@ class FaultTreeApp:
                 for ra in self.reliability_analyses
             ],
             "hazop_entries": [asdict(e) for e in self.hazop_entries],
+            "hara_entries": [asdict(e) for e in self.hara_entries],
             "fi2tc_entries": self.fi2tc_entries,
             "tc2fi_entries": self.tc2fi_entries,
             "scenario_libraries": self.scenario_libraries,
@@ -9734,6 +9739,8 @@ class FaultTreeApp:
             )
 
         self.hazop_entries = [HazopEntry(**h) for h in data.get("hazop_entries", [])]
+        self.hara_entries = [HaraEntry(**h) for h in data.get("hara_entries", [])]
+        self.sync_hara_to_safety_goals()
         self.fi2tc_entries = data.get("fi2tc_entries", [])
         self.tc2fi_entries = data.get("tc2fi_entries", [])
         self.scenario_libraries = data.get("scenario_libraries", [])

--- a/README.md
+++ b/README.md
@@ -68,6 +68,15 @@ Covered malfunctions may reference other entries as mitigation. When a function
 is allocated to an active component in a reliability analysis, its malfunctions
 become selectable failure modes in the FMEDA table.
 
+### HARA Analysis
+
+The **HARA Analysis** view builds on the safety relevant malfunctions from the
+selected HAZOP. For every malfunction you can assign severity, controllability
+and exposure levels along with textual rationales. The tool automatically
+calculates the resulting ASIL and lets you link each entry to a defined safety
+goal. ASIL values from these HARA entries are propagated to the linked safety
+goals and appear in FTA top level events and related documentation.
+
 ## License
 
 This project is licensed under the GNU General Public License version 3. See the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
## Summary
- save and load HARA entries alongside other model data
- propagate HARA ASILs when models load
- add Hazard menu with HAZOP and HARA windows
- document HARA analysis

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_b_6880750f5e50832597ac844581994852