### PR TITLE
Ensure HARA ASILs propagate to safety goals

### DIFF
--- a/AutoSafeguard.py
+++ b/AutoSafeguard.py
@@ -2218,7 +2218,7 @@ class FaultTreeApp:
         return best
 
     def sync_hara_to_safety_goals(self):
-        """Propagate ASIL values from HARA entries to safety goals."""
+        """Propagate ASIL values from all HARA documents to safety goals."""
         asil_map = {}
         for doc in getattr(self, "hara_docs", []):
             for e in doc.entries:
@@ -2227,14 +2227,6 @@ class FaultTreeApp:
                 cur = asil_map.get(e.safety_goal, "QM")
                 if ASIL_ORDER.get(e.asil, 0) > ASIL_ORDER.get(cur, 0):
                     asil_map[e.safety_goal] = e.asil
-        for te in self.top_events:
-            name = te.safety_goal_description or (te.user_name or f"SG {te.unique_id}")
-            if name in asil_map:
-                te.safety_goal_asil = asil_map[name]
-
-    def sync_hara_to_safety_goals(self):
-        """Propagate ASIL values from HARA entries to safety goals."""
-        asil_map = {e.safety_goal: e.asil for e in self.hara_entries if e.safety_goal}
         for te in self.top_events:
             name = te.safety_goal_description or (te.user_name or f"SG {te.unique_id}")
             if name in asil_map:

--- a/README.md
+++ b/README.md
@@ -71,11 +71,24 @@ become selectable failure modes in the FMEDA table.
 ### HARA Analysis
 
 The **HARA Analysis** view builds on the safety relevant malfunctions from the
-selected HAZOP. For every malfunction you can assign severity, controllability
-and exposure levels along with textual rationales. The tool automatically
-calculates the resulting ASIL and lets you link each entry to a defined safety
-goal. ASIL values from these HARA entries are propagated to the linked safety
-goals and appear in FTA top level events and related documentation.
+selected HAZOP. Each HARA table contains the following columns:
+
+1. **Malfunction** – combo box listing malfunctions flagged as safety relevant
+   in the chosen HAZOP document.
+2. **Severity** – ISO&nbsp;26262 severity level (1–3).
+3. **Severity Rationale** – free text explanation for the chosen severity.
+4. **Controllability** – ISO&nbsp;26262 controllability level (1–3).
+5. **Controllability Rationale** – free text explanation for the chosen
+   controllability.
+6. **Exposure** – ISO&nbsp;26262 exposure level (1–4).
+7. **Exposure Rationale** – free text explanation for the chosen exposure.
+8. **ASIL** – automatically calculated from severity, controllability and
+   exposure using the ISO&nbsp;26262 risk graph.
+9. **Safety Goal** – combo box listing all defined safety goals in the project.
+
+The calculated ASIL from each row is propagated to the referenced safety goal so
+that inherited ASIL levels appear consistently in all analyses and
+documentation, including FTA top level events.
 
 ## License
 


### PR DESCRIPTION
## Summary
- fix duplicate `sync_hara_to_safety_goals` function
- propagate ASIL values from every HARA document
- document HARA columns in README

## Testing
- `python -m py_compile AutoSafeguard.py models.py toolboxes.py review_toolbox.py drawing_helper.py mechanisms.py risk_assessment.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68808d55ba508325a8815f2d8adcd4c6