### PR TITLE
Allow HARA to select multiple HAZOPs

### DIFF
--- a/AutoSafeguard.py
+++ b/AutoSafeguard.py
@@ -10418,7 +10418,7 @@ class FaultTreeApp:
             "haras": [
                 {
                     "name": doc.name,
-                    "hazop": doc.hazop,
+                    "hazops": getattr(doc, "hazops", []),
                     "entries": [asdict(e) for e in doc.entries],
                     "approved": getattr(doc, "approved", False),
                 }
@@ -10578,17 +10578,23 @@ class FaultTreeApp:
         self.hara_docs = []
         for d in data.get("haras", []):
             entries = [HaraEntry(**e) for e in d.get("entries", [])]
+            hazops = d.get("hazops")
+            if not hazops:
+                hazop = d.get("hazop")
+                hazops = [hazop] if hazop else []
             self.hara_docs.append(
                 HaraDoc(
                     d.get("name", f"HARA {len(self.hara_docs)+1}"),
-                    d.get("hazop", ""),
+                    hazops,
                     entries,
                     d.get("approved", False),
                 )
             )
         if not self.hara_docs and "hara_entries" in data:
             hazop_name = self.hazop_docs[0].name if self.hazop_docs else ""
-            self.hara_docs.append(HaraDoc("Default", hazop_name, [HaraEntry(**e) for e in data.get("hara_entries", [])]))
+            self.hara_docs.append(
+                HaraDoc("Default", [hazop_name] if hazop_name else [], [HaraEntry(**e) for e in data.get("hara_entries", [])])
+            )
         self.active_hara = self.hara_docs[0] if self.hara_docs else None
         self.hara_entries = self.active_hara.entries if self.active_hara else []
 

--- a/README.md
+++ b/README.md
@@ -70,11 +70,13 @@ become selectable failure modes in the FMEDA table.
 
 ### HARA Analysis
 
-The **HARA Analysis** view builds on the safety relevant malfunctions from the
-selected HAZOP. Each HARA table contains the following columns:
+The **HARA Analysis** view builds on the safety relevant malfunctions from one
+or more selected HAZOPs. When creating a new HARA you can pick multiple HAZOP
+documents; only malfunctions from those selections appear in the table.
+Each HARA table contains the following columns:
 
 1. **Malfunction** – combo box listing malfunctions flagged as safety relevant
-   in the chosen HAZOP document.
+   in the chosen HAZOP documents.
 2. **Severity** – ISO&nbsp;26262 severity level (1–3).
 3. **Severity Rationale** – free text explanation for the chosen severity.
 4. **Controllability** – ISO&nbsp;26262 controllability level (1–3).

--- a/models.py
+++ b/models.py
@@ -100,9 +100,9 @@ class HazopDoc:
 
 @dataclass
 class HaraDoc:
-    """Container for a HARA linked to a specific HAZOP."""
+    """Container for a HARA derived from one or more HAZOPs."""
     name: str
-    hazop: str
+    hazops: list
     entries: list
     approved: bool = False
 


### PR DESCRIPTION
## Summary
- support choosing multiple HAZOPs when creating a HARA
- update dataclasses and JSON load/save for new `hazops` field
- aggregate malfunctions from all selected HAZOPs in the HARA row dialog
- document multi-select HAZOP feature in README

## Testing
- `python -m py_compile *.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_688099dba7fc83258bb9b5f9ab5855eb