### PR TITLE
Fix joint review checks and ASIL risk table

### DIFF
--- a/AutoSafeguard.py
+++ b/AutoSafeguard.py
@@ -11220,18 +11220,35 @@ class FaultTreeApp:
                 scope.result if scope.result else ([], [], [], [], [])
             )
 
-            # Ensure each selected element has an approved peer review
+            # Ensure each selected element has a completed peer review
+            def peer_completed(pred):
+                return any(
+                    r.mode == 'peer'
+                    and (r.approved or self.review_is_closed_for(r))
+                    and pred(r)
+                    for r in self.reviews
+                )
+
             for tid in fta_ids:
-                if not any(r.mode == 'peer' and r.approved and tid in r.fta_ids for r in self.reviews):
-                    messagebox.showerror("Review", "Peer review must be approved before starting joint review")
+                if not peer_completed(lambda r: tid in r.fta_ids):
+                    messagebox.showerror(
+                        "Review",
+                        "Peer review must be approved or closed before starting joint review",
+                    )
                     return
             for name_fta in fmea_names:
-                if not any(r.mode == 'peer' and r.approved and name_fta in r.fmea_names for r in self.reviews):
-                    messagebox.showerror("Review", "Peer review must be approved before starting joint review")
+                if not peer_completed(lambda r: name_fta in r.fmea_names):
+                    messagebox.showerror(
+                        "Review",
+                        "Peer review must be approved or closed before starting joint review",
+                    )
                     return
             for name_fd in fmeda_names:
-                if not any(r.mode == 'peer' and r.approved and name_fd in r.fmeda_names for r in self.reviews):
-                    messagebox.showerror("Review", "Peer review must be approved before starting joint review")
+                if not peer_completed(lambda r: name_fd in r.fmeda_names):
+                    messagebox.showerror(
+                        "Review",
+                        "Peer review must be approved or closed before starting joint review",
+                    )
                     return
             review = ReviewData(name=name, description=description, mode='joint', moderators=moderators,
                                participants=participants, comments=[],

--- a/models.py
+++ b/models.py
@@ -301,13 +301,19 @@ ASIL_TARGETS = {
 }
 
 # Simplified ISO 26262 risk graph for ASIL determination
+# Controllability values follow the standard ordering where 1 is easily
+# controllable and 3 represents difficult or uncontrollable situations.
 ASIL_TABLE = {
-    (3, 1, 4): "D", (3, 1, 3): "D", (3, 1, 2): "C", (3, 1, 1): "B",
-    (3, 2, 4): "C", (3, 2, 3): "C", (3, 2, 2): "B", (3, 2, 1): "A",
-    (3, 3, 4): "B", (3, 3, 3): "B", (3, 3, 2): "A", (3, 3, 1): "QM",
-    (2, 1, 4): "C", (2, 1, 3): "C", (2, 1, 2): "B", (2, 1, 1): "A",
-    (2, 2, 4): "B", (2, 2, 3): "B", (2, 2, 2): "A", (2, 2, 1): "QM",
-    (2, 3, 4): "A", (2, 3, 3): "A", (2, 3, 2): "QM", (2, 3, 1): "QM",
+    # Severity 3 rows
+    (3, 1, 4): "C", (3, 2, 4): "D", (3, 3, 4): "D",
+    (3, 1, 3): "B", (3, 2, 3): "C", (3, 3, 3): "D",
+    (3, 1, 2): "A", (3, 2, 2): "B", (3, 3, 2): "C",
+    (3, 1, 1): "QM", (3, 2, 1): "A", (3, 3, 1): "B",
+    # Severity 2 rows
+    (2, 1, 4): "B", (2, 2, 4): "C", (2, 3, 4): "D",
+    (2, 1, 3): "A", (2, 2, 3): "B", (2, 3, 3): "C",
+    (2, 1, 2): "QM", (2, 2, 2): "A", (2, 3, 2): "B",
+    (2, 1, 1): "QM", (2, 2, 1): "QM", (2, 3, 1): "A",
 }
 
 def calc_asil(sev: int, cont: int, expo: int) -> str:


### PR DESCRIPTION
## Summary
- allow joint reviews when the peer review is closed
- update ASIL lookup table so higher controllability numbers lead to higher ASIL levels according to ISO 26262

## Testing
- `python -m py_compile AutoSafeguard.py review_toolbox.py models.py toolboxes.py risk_assessment.py drawing_helper.py mechanisms.py`
- `python - <<'PY'
from models import calc_asil
for sev in [3,2]:
    for expo in [4,3,2,1]:
        print(sev, expo, [calc_asil(sev,c,expo) for c in [1,2,3]])
PY`

------
https://chatgpt.com/codex/tasks/task_b_6880f5a22df88325b12a550ed52e8412