### PR TITLE
Automate HARA approval status

### DIFF
--- a/models.py
+++ b/models.py
@@ -105,6 +105,7 @@ class HaraDoc:
     hazops: list
     entries: list
     approved: bool = False
+    status: str = "draft"
 
 COMPONENT_ATTR_TEMPLATES = {
     "capacitor": {

--- a/review_toolbox.py
+++ b/review_toolbox.py
@@ -395,6 +395,7 @@ class ReviewToolbox(tk.Toplevel):
         self.destroy()
 
     def refresh_reviews(self):
+        self.app.update_hara_statuses()
         names = [r.name for r in self.app.reviews]
         self.review_combo['values'] = names
         if self.app.review_data:
@@ -569,6 +570,8 @@ class ReviewToolbox(tk.Toplevel):
         self.app.review_data.approved = True
         messagebox.showinfo("Approve", "Review approved")
         self.app.add_version()
+        self.app.update_hara_statuses()
+        self.app.sync_hara_to_safety_goals()
         self.refresh_reviews()
 
     def edit_review(self):


### PR DESCRIPTION
## Summary
- track HARA document status and remove manual approval button
- auto-update status when reviews are approved
- save/load HARA status in the model data
- propagate ASIL when a review closes

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_b_6880f6f0a2a08325a8e9532e1e185fb7