### PR TITLE
Fix ASIL persistence for decomposed requirements

### DIFF
--- a/toolboxes.py
+++ b/toolboxes.py
@@ -834,6 +834,7 @@ class HaraWindow(tk.Toplevel):
         self.refresh()
 
     def refresh_docs(self):
+        self.app.update_hara_statuses()
         names = [d.name for d in self.app.hara_docs]
         # Explicitly configure the combobox values to ensure Tkinter updates
         self.doc_cb.configure(values=names)
@@ -841,6 +842,7 @@ class HaraWindow(tk.Toplevel):
             self.doc_var.set(self.app.active_hara.name)
             hazops = ", ".join(getattr(self.app.active_hara, "hazops", []))
             self.hazop_lbl.config(text=f"HAZOPs: {hazops}")
+            self.status_lbl.config(text=f"Status: {getattr(self.app.active_hara, 'status', 'draft')}")
 
         elif names:
             self.doc_var.set(names[0])
@@ -849,6 +851,7 @@ class HaraWindow(tk.Toplevel):
             self.hazop_lbl.config(text=f"HAZOPs: {hazops}")
             self.app.active_hara = doc
             self.app.hara_entries = doc.entries
+            self.status_lbl.config(text=f"Status: {getattr(doc, 'status', 'draft')}")
 
     def select_doc(self, *_):
         name = self.doc_var.get()
@@ -858,6 +861,7 @@ class HaraWindow(tk.Toplevel):
                 self.app.hara_entries = d.entries
                 hazops = ", ".join(getattr(d, "hazops", []))
                 self.hazop_lbl.config(text=f"HAZOPs: {hazops}")
+                self.status_lbl.config(text=f"Status: {getattr(d, 'status', 'draft')}")
                 break
         self.refresh()
 


### PR DESCRIPTION
## Summary
- track whether safety requirements are decomposed
- skip ASIL recalculation for decomposed requirements
- hide decomposed requirements from allocation dialogs
- prevent re‑allocation in traceability dialog
- export new flag when adding requirements

## Testing
- `python3 -m py_compile models.py AutoSafeguard.py toolboxes.py review_toolbox.py drawing_helper.py mechanisms.py risk_assessment.py`


------
https://chatgpt.com/codex/tasks/task_b_68810533567483258f950ef7c0439099