### PR TITLE
Improve reliability calculations

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,16 @@ interpreted:
 Mission profiles and the selected formula for each basic event are stored in the
 JSON model so results remain consistent when reloading the file.
 
+### Component Qualifications
+
+Reliability calculations now take the qualification certificate of each passive
+component into account.  When computing FIT rates, a multiplier based on the
+certificate (e.g. *AEC‑Q200* or *MIL‑STD‑883*) is applied so qualified parts
+yield lower failure rates.  Active components currently use a neutral factor.
+Additional datasheet parameters such as diode forward voltage or MOSFET
+`RDS(on)` can be entered when configuring components to better document the
+parts used in the analysis.
+
 ### HAZOP Analysis
 
 The **HAZOP Analysis** window lets you list system functions with one or more

--- a/models.py
+++ b/models.py
@@ -53,6 +53,22 @@ QUALIFICATIONS = [
     "None",
 ]
 
+# Multiplicative FIT adjustment factors applied to passive components based on
+# their qualification certificate.  Values below 1.0 decrease the calculated
+# FIT rate.  Active components currently use a factor of ``1.0`` regardless of
+# qualification.
+PASSIVE_QUAL_FACTORS = {
+    "AEC-Q200": 0.8,
+    "IECQ": 0.9,
+    "MIL-STD-883": 0.85,
+    "MIL-PRF-38534": 0.85,
+    "MIL-PRF-38535": 0.85,
+    "Space": 0.75,
+    "AEC-Q100": 1.0,
+    "AEC-Q101": 1.0,
+    "None": 1.0,
+}
+
 @dataclass
 class ReliabilityAnalysis:
     """Store the results of a reliability calculation including the BOM."""
@@ -129,12 +145,18 @@ COMPONENT_ATTR_TEMPLATES = {
         "type": ["standard", "zener", "schottky"],
         "reverse_V": "",
         "forward_current_A": "",
+        "forward_voltage_V": "",
+        "power_W": "",
+        "surge_current_A": "",
     },
     "transistor": {
         "transistor_type": ["BJT", "MOSFET"],
         "pins": "",
         "voltage_V": "",
         "current_A": "",
+        "gain_hfe": "",
+        "rds_on_mohm": "",
+        "gate_charge_nC": "",
     },
     "ic": {
         "type": ["digital", "analog", "mcu"],

--- a/toolboxes.py
+++ b/toolboxes.py
@@ -12,6 +12,7 @@ from models import (
     QUALIFICATIONS,
     COMPONENT_ATTR_TEMPLATES,
     RELIABILITY_MODELS,
+    PASSIVE_QUAL_FACTORS,
     calc_asil,
 )
 
@@ -319,7 +320,8 @@ class ReliabilityWindow(tk.Toplevel):
                     for sub in bom:
                         info = RELIABILITY_MODELS.get(std, {}).get(sub.comp_type)
                         if info:
-                            sub.fit = info["formula"](sub.attributes, mp) * mp.tau
+                            qf = PASSIVE_QUAL_FACTORS.get(sub.qualification, 1.0) if sub.is_passive else 1.0
+                            sub.fit = info["formula"](sub.attributes, mp) * mp.tau * qf
                         else:
                             sub.fit = 0.0
                         sub_total += sub.fit * sub.quantity
@@ -327,7 +329,8 @@ class ReliabilityWindow(tk.Toplevel):
             else:
                 info = RELIABILITY_MODELS.get(std, {}).get(comp.comp_type)
                 if info:
-                    comp.fit = info["formula"](comp.attributes, mp) * mp.tau
+                    qf = PASSIVE_QUAL_FACTORS.get(comp.qualification, 1.0) if comp.is_passive else 1.0
+                    comp.fit = info["formula"](comp.attributes, mp) * mp.tau * qf
                 else:
                     comp.fit = 0.0
             total += comp.fit * comp.quantity


### PR DESCRIPTION
## Summary
- account for passive part qualification when computing FIT rates
- expand component attribute templates with common datasheet fields
- expose qualification factors in toolboxes
- document new behaviour in README

## Testing
- `python -m py_compile models.py toolboxes.py AutoSafeguard.py mechanisms.py risk_assessment.py drawing_helper.py review_toolbox.py`

------
https://chatgpt.com/codex/tasks/task_b_68813ccae23c8325b260defbe51bde92