### PR TITLE
Update requirements after HARA approval

### DIFF
--- a/AutoSafeguard.py
+++ b/AutoSafeguard.py
@@ -1162,10 +1162,31 @@ class EditNodeDialog(simpledialog.Dialog):
                 continue  # keep decomposition ASIL
             self.update_requirement_asil(rid)
 
+    def update_requirement_decomposition(self):
+        """Update ASIL values of decomposed child requirements."""
+        parent_map = {}
+        for req in global_requirements.values():
+            pid = req.get("parent_id")
+            if pid:
+                parent_map.setdefault(pid, []).append(req)
+
+        for pid, children in parent_map.items():
+            parent = global_requirements.get(pid)
+            if not parent or len(children) < 2:
+                continue
+            schemes = ASIL_DECOMP_SCHEMES.get(parent.get("asil", "QM"), [])
+            if not schemes:
+                continue
+            asil_a, asil_b = schemes[0]
+            children_sorted = sorted(children, key=lambda r: r.get("id"))
+            children_sorted[0]["asil"] = asil_a
+            children_sorted[1]["asil"] = asil_b
+
     def ensure_asil_consistency(self):
         """Sync safety goal ASILs from HARAs and update requirement ASILs."""
         self.sync_hara_to_safety_goals()
         self.update_all_requirement_asil()
+        self.update_requirement_decomposition()
 
     
     def add_safety_requirement(self):

--- a/toolboxes.py
+++ b/toolboxes.py
@@ -1028,7 +1028,8 @@ class HaraWindow(tk.Toplevel):
         self.app.active_hara.status = "closed"
         self.app.active_hara.approved = True
         self.app.update_hara_statuses()
-        self.app.sync_hara_to_safety_goals()
+        self.app.ensure_asil_consistency()
+        self.app.update_views()
         messagebox.showinfo("HARA", "HARA approved")
 
 


### PR DESCRIPTION
## Summary
- refresh decomposed requirement ASIL values from parent ASIL
- ensure `ensure_asil_consistency()` also updates decomposition
- refresh all ASILs and the view when approving a HARA

## Testing
- `python -m py_compile AutoSafeguard.py toolboxes.py models.py risk_assessment.py drawing_helper.py review_toolbox.py`

------
https://chatgpt.com/codex/tasks/task_b_68813fa528808325af9381ff3b7c4ca2