### PR TITLE
Add requirement decomposition update option

### DIFF
--- a/AutoSafeguard.py
+++ b/AutoSafeguard.py
@@ -764,6 +764,8 @@ class EditNodeDialog(simpledialog.Dialog):
             self.add_existing_req_button.grid(row=1, column=3, padx=2, pady=2)
             self.decomp_req_button = ttk.Button(self.safety_req_frame, text="Decompose", command=self.decompose_safety_requirement)
             self.decomp_req_button.grid(row=1, column=4, padx=2, pady=2)
+            self.update_decomp_button = ttk.Button(self.safety_req_frame, text="Update Scheme", command=self.update_decomposition_scheme)
+            self.update_decomp_button.grid(row=1, column=5, padx=2, pady=2)
 
         elif self.node.node_type.upper() == "BASIC EVENT":
             ttk.Label(master, text="Failure Probability:").grid(row=row_next, column=0, padx=5, pady=5, sticky="e")
@@ -819,6 +821,8 @@ class EditNodeDialog(simpledialog.Dialog):
             self.add_existing_req_button.grid(row=1, column=3, padx=2, pady=2)
             self.decomp_req_button = ttk.Button(self.safety_req_frame, text="Decompose", command=self.decompose_safety_requirement)
             self.decomp_req_button.grid(row=1, column=4, padx=2, pady=2)
+            self.update_decomp_button = ttk.Button(self.safety_req_frame, text="Update Scheme", command=self.update_decomposition_scheme)
+            self.update_decomp_button.grid(row=1, column=5, padx=2, pady=2)
 
         elif self.node.node_type.upper() in ["GATE", "RIGOR LEVEL", "TOP EVENT"]:
             ttk.Label(master, text="Gate Type:").grid(row=row_next, column=0, padx=5, pady=5, sticky="e")
@@ -1321,6 +1325,40 @@ class EditNodeDialog(simpledialog.Dialog):
             index + 1,
             f"[{r2['id']}] [{r2['req_type']}] [{r2.get('asil','')}] {r2['text']}",
         )
+
+    def update_decomposition_scheme(self):
+        selected = self.safety_req_listbox.curselection()
+        if not selected:
+            messagebox.showwarning("Update Decomposition", "Select a decomposed requirement.")
+            return
+        index = selected[0]
+        req = self.node.safety_requirements[index]
+        parent_id = req.get("parent_id")
+        if not parent_id:
+            messagebox.showwarning("Update Decomposition", "Selected requirement is not decomposed.")
+            return
+        pair_indices = [i for i, r in enumerate(self.node.safety_requirements) if r.get("parent_id") == parent_id]
+        if len(pair_indices) != 2:
+            messagebox.showerror("Update Decomposition", "Could not identify decomposition pair.")
+            return
+        parent_req = global_requirements.get(parent_id, {})
+        dlg = DecompositionDialog(self, parent_req.get("asil", "QM"))
+        if not dlg.result:
+            return
+        asil_a, asil_b = dlg.result
+        pair_indices.sort()
+        req_a = self.node.safety_requirements[pair_indices[0]]
+        req_b = self.node.safety_requirements[pair_indices[1]]
+        req_a["asil"] = asil_a
+        req_b["asil"] = asil_b
+        global_requirements[req_a["id"]] = req_a
+        global_requirements[req_b["id"]] = req_b
+        for idx, r in zip(pair_indices, (req_a, req_b)):
+            self.safety_req_listbox.delete(idx)
+            self.safety_req_listbox.insert(idx, f"[{r['id']}] [{r['req_type']}] [{r.get('asil','')}] {r['text']}")
+        if self.node.node_type.upper() != "BASIC EVENT":
+            self.update_requirement_asil(req_a["id"])
+            self.update_requirement_asil(req_b["id"])
 
     def buttonbox(self):
         box = tk.Frame(self)

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Launch the review features from the **Review** menu:
 * **Merge Review Comments** – combine feedback from another saved model into the current one so parallel reviews can be consolidated.
 * **Compare Versions** – view earlier approved versions. Differences are listed with a short description and small before/after images of changed FTA nodes. Requirement allocations are compared in the diagrams and logs.
 * **Set Current User** – choose who you are when adding comments. The toolbox also provides a drop-down selector.
+* **Update Decomposition** – after splitting a requirement into two, select either child and use the new button in the node dialog to pick a different ASIL pair.
 * The target selector within the toolbox only lists nodes and FMEA items that were chosen when the review was created, so comments can only be attached to the scoped elements.
 
 Nodes with unresolved comments show a small yellow circle to help locate feedback quickly.


### PR DESCRIPTION
## Summary
- allow editing the decomposition scheme for decomposed requirements
- document the new capability in README

## Testing
- `python3 -m py_compile AutoSafeguard.py`

------
https://chatgpt.com/codex/tasks/task_b_68813fdafa1c8325a17c8cb12e892620