### PR TITLE
Add requirement decomposition update option

### DIFF
--- a/AutoSafeguard.py
+++ b/AutoSafeguard.py
@@ -764,6 +764,8 @@ class EditNodeDialog(simpledialog.Dialog):
             self.add_existing_req_button.grid(row=1, column=3, padx=2, pady=2)
             self.decomp_req_button = ttk.Button(self.safety_req_frame, text="Decompose", command=self.decompose_safety_requirement)
             self.decomp_req_button.grid(row=1, column=4, padx=2, pady=2)
+            self.update_decomp_button = ttk.Button(self.safety_req_frame, text="Update Scheme", command=self.update_decomposition_scheme)
+            self.update_decomp_button.grid(row=1, column=5, padx=2, pady=2)
 
         elif self.node.node_type.upper() == "BASIC EVENT":
             ttk.Label(master, text="Failure Probability:").grid(row=row_next, column=0, padx=5, pady=5, sticky="e")
@@ -819,6 +821,8 @@ class EditNodeDialog(simpledialog.Dialog):
             self.add_existing_req_button.grid(row=1, column=3, padx=2, pady=2)
             self.decomp_req_button = ttk.Button(self.safety_req_frame, text="Decompose", command=self.decompose_safety_requirement)
             self.decomp_req_button.grid(row=1, column=4, padx=2, pady=2)
+            self.update_decomp_button = ttk.Button(self.safety_req_frame, text="Update Scheme", command=self.update_decomposition_scheme)
+            self.update_decomp_button.grid(row=1, column=5, padx=2, pady=2)
 
         elif self.node.node_type.upper() in ["GATE", "RIGOR LEVEL", "TOP EVENT"]:
             ttk.Label(master, text="Gate Type:").grid(row=row_next, column=0, padx=5, pady=5, sticky="e")
@@ -1321,6 +1325,40 @@ class EditNodeDialog(simpledialog.Dialog):
             index + 1,
             f"[{r2['id']}] [{r2['req_type']}] [{r2.get('asil','')}] {r2['text']}",
         )
+
+    def update_decomposition_scheme(self):
+        selected = self.safety_req_listbox.curselection()
+        if not selected:
+            messagebox.showwarning("Update Decomposition", "Select a decomposed requirement.")
+            return
+        index = selected[0]
+        req = self.node.safety_requirements[index]
+        parent_id = req.get("parent_id")
+        if not parent_id:
+            messagebox.showwarning("Update Decomposition", "Selected requirement is not decomposed.")
+            return
+        pair_indices = [i for i, r in enumerate(self.node.safety_requirements) if r.get("parent_id") == parent_id]
+        if len(pair_indices) != 2:
+            messagebox.showerror("Update Decomposition", "Could not identify decomposition pair.")
+            return
+        parent_req = global_requirements.get(parent_id, {})
+        dlg = DecompositionDialog(self, parent_req.get("asil", "QM"))
+        if not dlg.result:
+            return
+        asil_a, asil_b = dlg.result
+        pair_indices.sort()
+        req_a = self.node.safety_requirements[pair_indices[0]]
+        req_b = self.node.safety_requirements[pair_indices[1]]
+        req_a["asil"] = asil_a
+        req_b["asil"] = asil_b
+        global_requirements[req_a["id"]] = req_a
+        global_requirements[req_b["id"]] = req_b
+        for idx, r in zip(pair_indices, (req_a, req_b)):
+            self.safety_req_listbox.delete(idx)
+            self.safety_req_listbox.insert(idx, f"[{r['id']}] [{r['req_type']}] [{r.get('asil','')}] {r['text']}")
+        if self.node.node_type.upper() != "BASIC EVENT":
+            self.update_requirement_asil(req_a["id"])
+            self.update_requirement_asil(req_b["id"])
 
     def buttonbox(self):
         box = tk.Frame(self)
@@ -11409,7 +11447,7 @@ class FaultTreeApp:
             def peer_completed(pred):
                 return any(
                     r.mode == 'peer'
-                    and (getattr(r, 'reviewed', False) or self.review_is_closed_for(r))
+                    and getattr(r, 'reviewed', False)
                     and pred(r)
                     for r in self.reviews
                 )
@@ -11418,21 +11456,21 @@ class FaultTreeApp:
                 if not peer_completed(lambda r: tid in r.fta_ids):
                     messagebox.showerror(
                         "Review",
-                        "Peer review must be approved or closed before starting joint review",
+                        "Peer review must be reviewed before starting joint review",
                     )
                     return
             for name_fta in fmea_names:
                 if not peer_completed(lambda r: name_fta in r.fmea_names):
                     messagebox.showerror(
                         "Review",
-                        "Peer review must be approved or closed before starting joint review",
+                        "Peer review must be reviewed before starting joint review",
                     )
                     return
             for name_fd in fmeda_names:
                 if not peer_completed(lambda r: name_fd in r.fmeda_names):
                     messagebox.showerror(
                         "Review",
-                        "Peer review must be approved or closed before starting joint review",
+                        "Peer review must be reviewed before starting joint review",
                     )
                     return
             review = ReviewData(name=name, description=description, mode='joint', moderators=moderators,
@@ -11453,6 +11491,8 @@ class FaultTreeApp:
             return
         if not self.review_data and self.reviews:
             self.review_data = self.reviews[0]
+        self.update_hara_statuses()
+        self.update_requirement_statuses()
         if self.review_window is None or not self.review_window.winfo_exists():
             self.review_window = ReviewToolbox(self.root, self)
         self.set_current_user()
@@ -11814,6 +11854,34 @@ class FaultTreeApp:
                         status = "in review"
                 if status_order[status] > status_order.get(req.get("status", "draft"), 0):
                     req["status"] = status
+
+
+    def compute_requirement_asil(self, req_id):
+        """Return highest ASIL across all safety goals linked to the requirement."""
+        goals = self.get_requirement_goal_names(req_id)
+        asil = "QM"
+        for g in goals:
+            a = self.get_safety_goal_asil(g)
+            if ASIL_ORDER.get(a, 0) > ASIL_ORDER.get(asil, 0):
+                asil = a
+        return asil
+
+    def update_requirement_asil(self, req_id):
+        req = global_requirements.get(req_id)
+        if not req:
+            return
+        req["asil"] = self.compute_requirement_asil(req_id)
+
+    def update_all_requirement_asil(self):
+        for rid, req in global_requirements.items():
+            if req.get("parent_id"):
+                continue  # keep decomposition ASIL
+            self.update_requirement_asil(rid)
+
+    def ensure_asil_consistency(self):
+        """Sync safety goal ASILs from HARAs and update requirement ASILs."""
+        self.sync_hara_to_safety_goals()
+        self.update_all_requirement_asil()
 
 
     def add_version(self):

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Launch the review features from the **Review** menu:
 * **Merge Review Comments** – combine feedback from another saved model into the current one so parallel reviews can be consolidated.
 * **Compare Versions** – view earlier approved versions. Differences are listed with a short description and small before/after images of changed FTA nodes. Requirement allocations are compared in the diagrams and logs.
 * **Set Current User** – choose who you are when adding comments. The toolbox also provides a drop-down selector.
+* **Update Decomposition** – after splitting a requirement into two, select either child and use the new button in the node dialog to pick a different ASIL pair.
 * The target selector within the toolbox only lists nodes and FMEA items that were chosen when the review was created, so comments can only be attached to the scoped elements.
 
 Nodes with unresolved comments show a small yellow circle to help locate feedback quickly.

--- a/review_toolbox.py
+++ b/review_toolbox.py
@@ -712,15 +712,17 @@ class ReviewToolbox(tk.Toplevel):
         else:
             approvers = [p for p in r.participants if p.role == 'approver']
             if approvers and all(p.approved for p in approvers) and all(c.resolved for c in r.comments):
+                newly_approved = False
                 if not r.approved:
                     r.approved = True
                     r.closed = True
                     self.app.add_version()
-                    self.app.update_hara_statuses()
-                    self.app.update_requirement_statuses()
-                    self.app.sync_hara_to_safety_goals()
-                    if hasattr(self.app, "_hara_window") and self.app._hara_window.winfo_exists():
-                        self.app._hara_window.refresh_docs()
+                    newly_approved = True
+                self.app.update_hara_statuses()
+                self.app.update_requirement_statuses()
+                self.app.sync_hara_to_safety_goals()
+                if hasattr(self.app, "_hara_window") and self.app._hara_window.winfo_exists():
+                    self.app._hara_window.refresh_docs()
                 self.refresh_reviews()
 
     def refresh_targets(self):


### PR DESCRIPTION
## Summary
- allow editing the decomposition scheme for decomposed requirements
- document the new capability in README
- refresh statuses once a review is approved
- block joint reviews until the selected documents have completed peer reviews
- add ASIL consistency helpers to FaultTreeApp

## Testing
- `python3 -m py_compile AutoSafeguard.py`

------
https://chatgpt.com/codex/tasks/task_b_68813fdafa1c8325a17c8cb12e892620