### PR TITLE
Enhance repository with packages and persistence

### DIFF
--- a/architecture.py
+++ b/architecture.py
@@ -3,6 +3,8 @@ from tkinter import ttk, simpledialog
 from dataclasses import dataclass, field
 from typing import Dict, List, Tuple
 
+from sysml_repository import SysMLRepository
+
 from sysml_spec import SYSML_PROPERTIES
 
 
@@ -22,6 +24,7 @@ class SysMLObject:
     obj_type: str
     x: float
     y: float
+    element_id: str | None = None
     width: float = 80.0
     height: float = 40.0
     properties: Dict[str, str] = field(default_factory=dict)
@@ -34,6 +37,8 @@ class SysMLDiagramWindow(tk.Toplevel):
         super().__init__(master)
         self.title(title)
         self.geometry("800x600")
+
+        self.repo = SysMLRepository.get_instance()
 
         self.zoom = 1.0
         self.current_tool = None
@@ -86,13 +91,19 @@ class SysMLDiagramWindow(tk.Toplevel):
             else:
                 if obj and obj != self.start:
                     self.connections.append((self.start.obj_id, obj.obj_id, t))
+                    src_id = self.start.element_id
+                    dst_id = obj.element_id
+                    if src_id and dst_id:
+                        self.repo.create_relationship(t, src_id, dst_id)
                 self.start = None
                 self.redraw()
         elif t and t != "Select":
-            new_obj = SysMLObject(_get_next_id(), t, x / self.zoom, y / self.zoom)
+            element = self.repo.create_element(t)
+            new_obj = SysMLObject(_get_next_id(), t, x / self.zoom, y / self.zoom, element_id=element.elem_id)
             key = f"{t.replace(' ', '')}Usage"
             for prop in SYSML_PROPERTIES.get(key, []):
                 new_obj.properties.setdefault(prop, "")
+            element.properties.update(new_obj.properties)
             self.objects.append(new_obj)
             self.redraw()
         else:
@@ -269,8 +280,13 @@ class SysMLObjectDialog(simpledialog.Dialog):
 
     def apply(self):
         self.obj.properties["name"] = self.name_var.get()
+        repo = SysMLRepository.get_instance()
+        if self.obj.element_id and self.obj.element_id in repo.elements:
+            repo.elements[self.obj.element_id].name = self.name_var.get()
         for prop, var in self.entries.items():
             self.obj.properties[prop] = var.get()
+            if self.obj.element_id and self.obj.element_id in repo.elements:
+                repo.elements[self.obj.element_id].properties[prop] = var.get()
         try:
             self.obj.width = float(self.width_var.get())
             self.obj.height = float(self.height_var.get())

--- a/sysml_repository.py
+++ b/sysml_repository.py
@@ -1,0 +1,112 @@
+import json
+import uuid
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+import os
+
+@dataclass
+class SysMLElement:
+    """Basic SysML element stored in the repository."""
+    elem_id: str
+    elem_type: str
+    name: str = ""
+    properties: Dict[str, str] = field(default_factory=dict)
+    stereotypes: Dict[str, str] = field(default_factory=dict)
+    owner: Optional[str] = None
+
+@dataclass
+class SysMLRelationship:
+    rel_id: str
+    rel_type: str
+    source: str
+    target: str
+    stereotype: Optional[str] = None
+    properties: Dict[str, str] = field(default_factory=dict)
+
+class SysMLRepository:
+    """Singleton repository for all SysML elements and relationships."""
+    _instance = None
+
+    def __init__(self):
+        self.elements: Dict[str, SysMLElement] = {}
+        self.relationships: List[SysMLRelationship] = []
+        self.root_package = self.create_element("Package", name="Root")
+
+    @classmethod
+    def get_instance(cls) -> "SysMLRepository":
+        if cls._instance is None:
+            cls._instance = SysMLRepository()
+        return cls._instance
+
+    def create_element(self, elem_type: str, name: str = "", properties: Optional[Dict[str, str]] = None, owner: Optional[str] = None) -> SysMLElement:
+        elem_id = str(uuid.uuid4())
+        elem = SysMLElement(elem_id, elem_type, name, properties or {}, owner=owner)
+        self.elements[elem_id] = elem
+        return elem
+
+    # ------------------------------------------------------------------
+    # Convenience helpers
+    # ------------------------------------------------------------------
+    def create_package(self, name: str, parent: Optional[str] = None) -> SysMLElement:
+        """Create a Package element optionally under a parent Package."""
+        if parent is None:
+            parent = self.root_package.elem_id
+        return self.create_element("Package", name=name, owner=parent)
+
+    def delete_element(self, elem_id: str) -> None:
+        """Remove an element and any relationships referencing it."""
+        if elem_id in self.elements:
+            del self.elements[elem_id]
+        self.relationships = [r for r in self.relationships if r.source != elem_id and r.target != elem_id]
+
+    def get_element(self, elem_id: str) -> Optional[SysMLElement]:
+        return self.elements.get(elem_id)
+
+    def get_qualified_name(self, elem_id: str) -> str:
+        elem = self.elements[elem_id]
+        parts = [elem.name or elem.elem_id]
+        current = elem.owner
+        while current:
+            parent = self.elements[current]
+            parts.append(parent.name or parent.elem_id)
+            current = parent.owner
+        return "::".join(reversed(parts))
+
+    def save(self, path: str) -> None:
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(self.serialize())
+
+    def load(self, path: str) -> None:
+        if not os.path.exists(path):
+            return
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        self.elements.clear()
+        self.relationships.clear()
+        for e in data.get("elements", []):
+            elem = SysMLElement(**e)
+            self.elements[elem.elem_id] = elem
+        for r in data.get("relationships", []):
+            rel = SysMLRelationship(**r)
+            self.relationships.append(rel)
+        self.root_package = None
+        for elem in self.elements.values():
+            if elem.elem_type == "Package" and elem.owner is None:
+                self.root_package = elem
+                break
+        if self.root_package is None:
+            self.root_package = self.create_element("Package", name="Root")
+
+    def create_relationship(self, rel_type: str, source: str, target: str, stereotype: Optional[str] = None, properties: Optional[Dict[str, str]] = None) -> SysMLRelationship:
+        rel_id = str(uuid.uuid4())
+        rel = SysMLRelationship(rel_id, rel_type, source, target, stereotype, properties or {})
+        self.relationships.append(rel)
+        return rel
+
+    def serialize(self) -> str:
+        data = {
+            "elements": [elem.__dict__ for elem in self.elements.values()],
+            "relationships": [rel.__dict__ for rel in self.relationships],
+        }
+        return json.dumps(data, indent=2)
+

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -1,0 +1,45 @@
+import unittest
+import os
+from sysml_repository import SysMLRepository
+
+class RepositoryTests(unittest.TestCase):
+    def setUp(self):
+        SysMLRepository._instance = None
+        self.repo = SysMLRepository.get_instance()
+
+    def test_create_elements(self):
+        actor = self.repo.create_element("Actor", name="User")
+        use_case = self.repo.create_element("Use Case", name="Login")
+        self.assertNotEqual(actor.elem_id, use_case.elem_id)
+        self.assertEqual(actor.name, "User")
+        self.assertEqual(use_case.name, "Login")
+
+    def test_create_relationship(self):
+        a = self.repo.create_element("Actor")
+        b = self.repo.create_element("Use Case")
+        rel = self.repo.create_relationship("Association", a.elem_id, b.elem_id)
+        self.assertEqual(rel.source, a.elem_id)
+        self.assertEqual(rel.target, b.elem_id)
+
+    def test_serialize(self):
+        blk = self.repo.create_element("Block", name="Car")
+        js = self.repo.serialize()
+        self.assertIn("Car", js)
+        self.assertIn(blk.elem_id, js)
+
+    def test_packages_and_save_load(self):
+        pkg = self.repo.create_package("PkgA")
+        blk = self.repo.create_element("Block", name="Engine", owner=pkg.elem_id)
+        qn = self.repo.get_qualified_name(blk.elem_id)
+        self.assertEqual(qn.split("::")[-1], "Engine")
+        path = "repo_test.json"
+        self.repo.save(path)
+        SysMLRepository._instance = None
+        new_repo = SysMLRepository.get_instance()
+        new_repo.load(path)
+        os.remove(path)
+        self.assertIn(blk.elem_id, new_repo.elements)
+        self.assertEqual(new_repo.get_qualified_name(blk.elem_id), qn)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add root package and support package creation
- provide qualified name utility, save and load methods, and delete helper
- update repository tests for new functionality

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6882414e2d088325bc401c562b3cf160