### PR TITLE
Enhance diagram handling and repository

### DIFF
--- a/AutoSafeguard.py
+++ b/AutoSafeguard.py
@@ -1851,6 +1851,10 @@ class FaultTreeApp:
         # Track the last saved state so we can prompt on exit
         self.last_saved_state = json.dumps(self.export_model_data(), sort_keys=True)
         root.protocol("WM_DELETE_WINDOW", self.confirm_close)
+        self.use_case_windows = []
+        self.activity_windows = []
+        self.block_windows = []
+        self.ibd_windows = []
 
     # --- Requirement Traceability Helpers used by reviews and matrix view ---
     def get_requirement_allocation_names(self, req_id):
@@ -10573,29 +10577,32 @@ class FaultTreeApp:
             return
         self._tc2fi_window = TC2FIWindow(self)
 
+    def _register_close(self, win, collection):
+        def _close():
+            if win in collection:
+                collection.remove(win)
+            win.destroy()
+        return _close
+
     def open_use_case_diagram(self):
-        if hasattr(self, "_use_case_window") and self._use_case_window.winfo_exists():
-            self._use_case_window.lift()
-            return
-        self._use_case_window = UseCaseDiagramWindow(self.root)
+        win = UseCaseDiagramWindow(self.root)
+        win.protocol("WM_DELETE_WINDOW", self._register_close(win, self.use_case_windows))
+        self.use_case_windows.append(win)
 
     def open_activity_diagram(self):
-        if hasattr(self, "_activity_window") and self._activity_window.winfo_exists():
-            self._activity_window.lift()
-            return
-        self._activity_window = ActivityDiagramWindow(self.root)
+        win = ActivityDiagramWindow(self.root)
+        win.protocol("WM_DELETE_WINDOW", self._register_close(win, self.activity_windows))
+        self.activity_windows.append(win)
 
     def open_block_diagram(self):
-        if hasattr(self, "_block_window") and self._block_window.winfo_exists():
-            self._block_window.lift()
-            return
-        self._block_window = BlockDiagramWindow(self.root)
+        win = BlockDiagramWindow(self.root)
+        win.protocol("WM_DELETE_WINDOW", self._register_close(win, self.block_windows))
+        self.block_windows.append(win)
 
     def open_internal_block_diagram(self):
-        if hasattr(self, "_ibd_window") and self._ibd_window.winfo_exists():
-            self._ibd_window.lift()
-            return
-        self._ibd_window = InternalBlockDiagramWindow(self.root)
+        win = InternalBlockDiagramWindow(self.root)
+        win.protocol("WM_DELETE_WINDOW", self._register_close(win, self.ibd_windows))
+        self.ibd_windows.append(win)
         
     def copy_node(self):
         if self.selected_node and self.selected_node != self.root_node:

--- a/sysml_repository.py
+++ b/sysml_repository.py
@@ -1,0 +1,146 @@
+import json
+import uuid
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+import os
+
+@dataclass
+class SysMLElement:
+    """Basic SysML element stored in the repository."""
+    elem_id: str
+    elem_type: str
+    name: str = ""
+    properties: Dict[str, str] = field(default_factory=dict)
+    stereotypes: Dict[str, str] = field(default_factory=dict)
+    owner: Optional[str] = None
+
+@dataclass
+class SysMLRelationship:
+    rel_id: str
+    rel_type: str
+    source: str
+    target: str
+    stereotype: Optional[str] = None
+    properties: Dict[str, str] = field(default_factory=dict)
+
+@dataclass
+class SysMLDiagram:
+    diag_id: str
+    diag_type: str
+    name: str = ""
+    elements: List[str] = field(default_factory=list)
+    relationships: List[str] = field(default_factory=list)
+
+class SysMLRepository:
+    """Singleton repository for all SysML elements and relationships."""
+    _instance = None
+
+    def __init__(self):
+        self.elements: Dict[str, SysMLElement] = {}
+        self.relationships: List[SysMLRelationship] = []
+        self.diagrams: Dict[str, SysMLDiagram] = {}
+        self.root_package = self.create_element("Package", name="Root")
+
+    @classmethod
+    def get_instance(cls) -> "SysMLRepository":
+        if cls._instance is None:
+            cls._instance = SysMLRepository()
+        return cls._instance
+
+    def create_element(self, elem_type: str, name: str = "", properties: Optional[Dict[str, str]] = None, owner: Optional[str] = None) -> SysMLElement:
+        elem_id = str(uuid.uuid4())
+        elem = SysMLElement(elem_id, elem_type, name, properties or {}, owner=owner)
+        self.elements[elem_id] = elem
+        return elem
+
+    # ------------------------------------------------------------------
+    # Convenience helpers
+    # ------------------------------------------------------------------
+    def create_package(self, name: str, parent: Optional[str] = None) -> SysMLElement:
+        """Create a Package element optionally under a parent Package."""
+        if parent is None:
+            parent = self.root_package.elem_id
+        return self.create_element("Package", name=name, owner=parent)
+
+    def create_diagram(self, diag_type: str, name: str = "") -> SysMLDiagram:
+        diag_id = str(uuid.uuid4())
+        diagram = SysMLDiagram(diag_id, diag_type, name)
+        self.diagrams[diag_id] = diagram
+        return diagram
+
+    def add_element_to_diagram(self, diag_id: str, elem_id: str) -> None:
+        diag = self.diagrams.get(diag_id)
+        if diag and elem_id not in diag.elements:
+            diag.elements.append(elem_id)
+
+    def add_relationship_to_diagram(self, diag_id: str, rel_id: str) -> None:
+        diag = self.diagrams.get(diag_id)
+        if diag and rel_id not in diag.relationships:
+            diag.relationships.append(rel_id)
+
+    def delete_element(self, elem_id: str) -> None:
+        """Remove an element and any relationships referencing it."""
+        if elem_id in self.elements:
+            del self.elements[elem_id]
+        self.relationships = [r for r in self.relationships if r.source != elem_id and r.target != elem_id]
+
+    def delete_diagram(self, diag_id: str) -> None:
+        if diag_id in self.diagrams:
+            del self.diagrams[diag_id]
+
+    def get_element(self, elem_id: str) -> Optional[SysMLElement]:
+        return self.elements.get(elem_id)
+
+    def get_qualified_name(self, elem_id: str) -> str:
+        elem = self.elements[elem_id]
+        parts = [elem.name or elem.elem_id]
+        current = elem.owner
+        while current:
+            parent = self.elements[current]
+            parts.append(parent.name or parent.elem_id)
+            current = parent.owner
+        return "::".join(reversed(parts))
+
+    def save(self, path: str) -> None:
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(self.serialize())
+
+    def load(self, path: str) -> None:
+        if not os.path.exists(path):
+            return
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        self.elements.clear()
+        self.relationships.clear()
+        self.diagrams.clear()
+        for e in data.get("elements", []):
+            elem = SysMLElement(**e)
+            self.elements[elem.elem_id] = elem
+        for r in data.get("relationships", []):
+            rel = SysMLRelationship(**r)
+            self.relationships.append(rel)
+        for d in data.get("diagrams", []):
+            diag = SysMLDiagram(**d)
+            self.diagrams[diag.diag_id] = diag
+        self.root_package = None
+        for elem in self.elements.values():
+            if elem.elem_type == "Package" and elem.owner is None:
+                self.root_package = elem
+                break
+        if self.root_package is None:
+            self.root_package = self.create_element("Package", name="Root")
+
+    def create_relationship(self, rel_type: str, source: str, target: str, stereotype: Optional[str] = None, properties: Optional[Dict[str, str]] = None) -> SysMLRelationship:
+        rel_id = str(uuid.uuid4())
+        rel = SysMLRelationship(rel_id, rel_type, source, target, stereotype, properties or {})
+        self.relationships.append(rel)
+        return rel
+
+    def serialize(self) -> str:
+        data = {
+            "elements": [elem.__dict__ for elem in self.elements.values()],
+            "relationships": [rel.__dict__ for rel in self.relationships],
+            "diagrams": [diag.__dict__ for diag in self.diagrams.values()],
+        }
+        return json.dumps(data, indent=2)
+

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -1,0 +1,58 @@
+import unittest
+import os
+from sysml_repository import SysMLRepository
+
+class RepositoryTests(unittest.TestCase):
+    def setUp(self):
+        SysMLRepository._instance = None
+        self.repo = SysMLRepository.get_instance()
+
+    def test_create_elements(self):
+        actor = self.repo.create_element("Actor", name="User")
+        use_case = self.repo.create_element("Use Case", name="Login")
+        self.assertNotEqual(actor.elem_id, use_case.elem_id)
+        self.assertEqual(actor.name, "User")
+        self.assertEqual(use_case.name, "Login")
+
+    def test_create_relationship(self):
+        a = self.repo.create_element("Actor")
+        b = self.repo.create_element("Use Case")
+        rel = self.repo.create_relationship("Association", a.elem_id, b.elem_id)
+        self.assertEqual(rel.source, a.elem_id)
+        self.assertEqual(rel.target, b.elem_id)
+
+    def test_serialize(self):
+        blk = self.repo.create_element("Block", name="Car")
+        js = self.repo.serialize()
+        self.assertIn("Car", js)
+        self.assertIn(blk.elem_id, js)
+
+    def test_packages_and_save_load(self):
+        pkg = self.repo.create_package("PkgA")
+        blk = self.repo.create_element("Block", name="Engine", owner=pkg.elem_id)
+        qn = self.repo.get_qualified_name(blk.elem_id)
+        self.assertEqual(qn.split("::")[-1], "Engine")
+        path = "repo_test.json"
+        self.repo.save(path)
+        SysMLRepository._instance = None
+        new_repo = SysMLRepository.get_instance()
+        new_repo.load(path)
+        os.remove(path)
+        self.assertIn(blk.elem_id, new_repo.elements)
+        self.assertEqual(new_repo.get_qualified_name(blk.elem_id), qn)
+
+    def test_diagram_creation_and_persistence(self):
+        diag = self.repo.create_diagram("Use Case Diagram", name="UC1")
+        actor = self.repo.create_element("Actor")
+        self.repo.add_element_to_diagram(diag.diag_id, actor.elem_id)
+        path = "repo_diag.json"
+        self.repo.save(path)
+        SysMLRepository._instance = None
+        new_repo = SysMLRepository.get_instance()
+        new_repo.load(path)
+        os.remove(path)
+        self.assertIn(diag.diag_id, new_repo.diagrams)
+        self.assertIn(actor.elem_id, new_repo.diagrams[diag.diag_id].elements)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- support multiple concurrent diagram windows
- track diagrams in the SysML repository and save/load their contents
- link diagram elements and relationships to stored diagrams
- expand repository tests to cover diagrams

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6882414e2d088325bc401c562b3cf160