### PR TITLE
Enhance SysML linking and navigation

### DIFF
--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -54,5 +54,19 @@ class RepositoryTests(unittest.TestCase):
         self.assertIn(diag.diag_id, new_repo.diagrams)
         self.assertIn(actor.elem_id, new_repo.diagrams[diag.diag_id].elements)
 
+    def test_element_diagram_linking(self):
+        uc = self.repo.create_element("Use Case")
+        ad = self.repo.create_diagram("Activity Diagram", name="AD1")
+        self.repo.link_diagram(uc.elem_id, ad.diag_id)
+        linked = self.repo.get_linked_diagram(uc.elem_id)
+        self.assertEqual(linked, ad.diag_id)
+        path = "repo_link.json"
+        self.repo.save(path)
+        SysMLRepository._instance = None
+        new_repo = SysMLRepository.get_instance()
+        new_repo.load(path)
+        os.remove(path)
+        self.assertEqual(new_repo.get_linked_diagram(uc.elem_id), ad.diag_id)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- extend repository with element→diagram links
- allow selecting diagrams in element dialog
- open linked diagrams on double-click
- keep diagram IDs persistent
- test diagram linking persistence

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68824b1fe7fc8325be7baa822a8b5b7e