### PR TITLE
Enable customizable connector styles

### DIFF
--- a/AutoSafeguard.py
+++ b/AutoSafeguard.py
@@ -273,7 +273,9 @@ from architecture import (
     ActivityDiagramWindow,
     BlockDiagramWindow,
     InternalBlockDiagramWindow,
+    ArchitectureManagerDialog,
 )
+from sysml_repository import SysMLRepository
 import copy
 import tkinter.font as tkFont
 from PIL import Image, ImageDraw, ImageFont, ImageTk
@@ -1747,6 +1749,8 @@ class FaultTreeApp:
         architecture_menu.add_command(label="Activity Diagram", command=self.open_activity_diagram)
         architecture_menu.add_command(label="Block Diagram", command=self.open_block_diagram)
         architecture_menu.add_command(label="Internal Block Diagram", command=self.open_internal_block_diagram)
+        architecture_menu.add_separator()
+        architecture_menu.add_command(label="Manage Architecture", command=self.manage_architecture)
         menubar.add_cascade(label="Architecture", menu=architecture_menu)
 
         hara_menu = tk.Menu(menubar, tearoff=0)
@@ -10610,6 +10614,9 @@ class FaultTreeApp:
         win = InternalBlockDiagramWindow(self.root)
         win.protocol("WM_DELETE_WINDOW", self._register_close(win, self.ibd_windows))
         self.ibd_windows.append(win)
+
+    def manage_architecture(self):
+        ArchitectureManagerDialog(self.root)
         
     def copy_node(self):
         if self.selected_node and self.selected_node != self.root_node:

--- a/architecture.py
+++ b/architecture.py
@@ -30,16 +30,28 @@ class SysMLObject:
     properties: Dict[str, str] = field(default_factory=dict)
 
 
+@dataclass
+class DiagramConnection:
+    src: int
+    dst: int
+    conn_type: str
+    style: str = "Straight"  # Straight, Squared, Custom
+    points: List[Tuple[float, float]] = field(default_factory=list)
+
+
 class SysMLDiagramWindow(tk.Toplevel):
     """Base window for simple SysML diagrams with zoom and pan support."""
 
-    def __init__(self, master, title, tools):
+    def __init__(self, master, title, tools, diagram_id: str | None = None):
         super().__init__(master)
         self.title(title)
         self.geometry("800x600")
 
         self.repo = SysMLRepository.get_instance()
-        diagram = self.repo.create_diagram(title)
+        if diagram_id and diagram_id in self.repo.diagrams:
+            diagram = self.repo.diagrams[diagram_id]
+        else:
+            diagram = self.repo.create_diagram(title, name=title, diag_id=diagram_id)
         self.diagram_id = diagram.diag_id
         self.protocol("WM_DELETE_WINDOW", self.on_close)
 
@@ -47,7 +59,7 @@ class SysMLDiagramWindow(tk.Toplevel):
         self.current_tool = None
         self.start = None
         self.objects: List[SysMLObject] = []
-        self.connections: List[Tuple[int, int, str]] = []
+        self.connections: List[DiagramConnection] = []
         self.selected_obj: SysMLObject | None = None
         self.drag_offset = (0, 0)
 
@@ -93,18 +105,24 @@ class SysMLDiagramWindow(tk.Toplevel):
                     self.start = obj
             else:
                 if obj and obj != self.start:
-                    self.connections.append((self.start.obj_id, obj.obj_id, t))
+                    conn = DiagramConnection(self.start.obj_id, obj.obj_id, t)
+                    self.connections.append(conn)
                     src_id = self.start.element_id
                     dst_id = obj.element_id
                     if src_id and dst_id:
                         rel = self.repo.create_relationship(t, src_id, dst_id)
                         self.repo.add_relationship_to_diagram(self.diagram_id, rel.rel_id)
+                    ConnectionDialog(self, conn)
                 self.start = None
                 self.redraw()
         elif t and t != "Select":
             element = self.repo.create_element(t)
             self.repo.add_element_to_diagram(self.diagram_id, element.elem_id)
-            new_obj = SysMLObject(_get_next_id(), t, x / self.zoom, y / self.zoom, element_id=element.elem_id)
+            new_obj = SysMLObject(_get_next_id(), t, x / self.zoom, y / self.zoom,
+                                  element_id=element.elem_id)
+            if t == "Block":
+                new_obj.height = 140.0
+                new_obj.width = 160.0
             key = f"{t.replace(' ', '')}Usage"
             for prop in SYSML_PROPERTIES.get(key, []):
                 new_obj.properties.setdefault(prop, "")
@@ -133,8 +151,22 @@ class SysMLDiagramWindow(tk.Toplevel):
         y = self.canvas.canvasy(event.y)
         obj = self.find_object(x, y)
         if obj:
+            diag_id = self.repo.get_linked_diagram(obj.element_id)
+            if diag_id and diag_id in self.repo.diagrams:
+                diag = self.repo.diagrams[diag_id]
+                if diag.diag_type == "Activity Diagram":
+                    ActivityDiagramWindow(self.master, diagram_id=diag_id)
+                    return
+                if diag.diag_type == "Internal Block Diagram":
+                    InternalBlockDiagramWindow(self.master, diagram_id=diag_id)
+                    return
             SysMLObjectDialog(self, obj)
             self.redraw()
+        else:
+            conn = self.find_connection(x, y)
+            if conn:
+                ConnectionDialog(self, conn)
+                self.redraw()
 
     def on_rc_press(self, event):
         self.canvas.scan_mark(event.x, event.y)
@@ -161,6 +193,40 @@ class SysMLDiagramWindow(tk.Toplevel):
                 return obj
         return None
 
+    def _dist_to_segment(self, p, a, b) -> float:
+        px, py = p
+        ax, ay = a
+        bx, by = b
+        if ax == bx and ay == by:
+            return ((px - ax) ** 2 + (py - ay) ** 2) ** 0.5
+        t = ((px - ax) * (bx - ax) + (py - ay) * (by - ay)) / ((bx - ax) ** 2 + (by - ay) ** 2)
+        t = max(0, min(1, t))
+        lx = ax + t * (bx - ax)
+        ly = ay + t * (by - ay)
+        return ((px - lx) ** 2 + (py - ly) ** 2) ** 0.5
+
+    def find_connection(self, x: float, y: float) -> DiagramConnection | None:
+        for conn in self.connections:
+            src = self.get_object(conn.src)
+            dst = self.get_object(conn.dst)
+            if not src or not dst:
+                continue
+            points = [(src.x * self.zoom, src.y * self.zoom)]
+            if conn.style == "Squared":
+                midx = (src.x + dst.x) / 2 * self.zoom
+                points.extend([(midx, points[-1][1]), (midx, dst.y * self.zoom)])
+            elif conn.style == "Custom":
+                for px, py in conn.points:
+                    xpt = px * self.zoom
+                    ypt = py * self.zoom
+                    last = points[-1]
+                    points.extend([(xpt, last[1]), (xpt, ypt)])
+            points.append((dst.x * self.zoom, dst.y * self.zoom))
+            for a, b in zip(points[:-1], points[1:]):
+                if self._dist_to_segment((x, y), a, b) <= 5:
+                    return conn
+        return None
+
     def zoom_in(self):
         self.zoom *= 1.2
         self.redraw()
@@ -173,11 +239,11 @@ class SysMLDiagramWindow(tk.Toplevel):
         self.canvas.delete("all")
         for obj in self.objects:
             self.draw_object(obj)
-        for a, b, _t in self.connections:
-            src = self.get_object(a)
-            dst = self.get_object(b)
+        for conn in self.connections:
+            src = self.get_object(conn.src)
+            dst = self.get_object(conn.dst)
             if src and dst:
-                self.draw_connection(src, dst)
+                self.draw_connection(src, dst, conn)
         self.canvas.config(scrollregion=self.canvas.bbox("all"))
 
     def draw_object(self, obj: SysMLObject):
@@ -200,7 +266,7 @@ class SysMLDiagramWindow(tk.Toplevel):
             self.canvas.create_rectangle(x - 100 * self.zoom, y - 60 * self.zoom,
                                         x + 100 * self.zoom, y + 60 * self.zoom,
                                         dash=(4, 2))
-        elif obj.obj_type in ("Action", "Block", "Part", "Port"):
+        elif obj.obj_type in ("Action", "Part", "Port"):
             dash = ()
             fill = ""
             if obj.obj_type == "Part":
@@ -213,6 +279,27 @@ class SysMLDiagramWindow(tk.Toplevel):
             else:
                 self.canvas.create_rectangle(x - w, y - h, x + w, y + h,
                                             dash=dash, fill=fill)
+        elif obj.obj_type == "Block":
+            left, top = x - w, y - h
+            right, bottom = x + w, y + h
+            self.canvas.create_rectangle(left, top, right, bottom)
+            header = f"<<block>> {obj.properties.get('name', '')}".strip()
+            self.canvas.create_line(left, top + 20 * self.zoom, right, top + 20 * self.zoom)
+            self.canvas.create_text(left + 4 * self.zoom, top + 10 * self.zoom, text=header, anchor="w")
+            compartments = [
+                ("Attributes", obj.properties.get("valueProperties", "")),
+                ("Parts", obj.properties.get("partProperties", "")),
+                ("References", obj.properties.get("referenceProperties", "")),
+                ("Operations", obj.properties.get("operations", "")),
+                ("Constraints", obj.properties.get("constraintProperties", "")),
+                ("Ports", obj.properties.get("ports", "")),
+            ]
+            cy = top + 20 * self.zoom
+            for label, text in compartments:
+                self.canvas.create_line(left, cy, right, cy)
+                display = f"{label}: {text}" if text else f"{label}:"
+                self.canvas.create_text(left + 4 * self.zoom, cy + 10 * self.zoom, text=display, anchor="w")
+                cy += 20 * self.zoom
         elif obj.obj_type in ("Initial", "Final"):
             if obj.obj_type == "Initial":
                 self.canvas.create_oval(x - 10 * self.zoom, y - 10 * self.zoom,
@@ -237,18 +324,39 @@ class SysMLDiagramWindow(tk.Toplevel):
         else:
             self.canvas.create_rectangle(x - w, y - h, x + w, y + h)
 
-        label_lines = [obj.properties.get("name", obj.obj_type)]
-        key = f"{obj.obj_type.replace(' ', '')}Usage"
-        for prop in SYSML_PROPERTIES.get(key, []):
-            val = obj.properties.get(prop)
-            if val:
-                label_lines.append(f"{prop}: {val}")
-        self.canvas.create_text(x, y, text="\n".join(label_lines), anchor="center")
+        if obj.obj_type != "Block":
+            label_lines = [obj.properties.get("name", obj.obj_type)]
+            key = f"{obj.obj_type.replace(' ', '')}Usage"
+            for prop in SYSML_PROPERTIES.get(key, []):
+                val = obj.properties.get(prop)
+                if val:
+                    label_lines.append(f"{prop}: {val}")
+            self.canvas.create_text(x, y, text="\n".join(label_lines), anchor="center")
 
-    def draw_connection(self, a: SysMLObject, b: SysMLObject):
+    def draw_connection(self, a: SysMLObject, b: SysMLObject, conn: DiagramConnection):
         ax, ay = a.x * self.zoom, a.y * self.zoom
         bx, by = b.x * self.zoom, b.y * self.zoom
-        self.canvas.create_line(ax, ay, bx, by, arrow=tk.LAST)
+        dash = ()
+        label = None
+        if conn.conn_type in ("Include", "Extend"):
+            dash = (4, 2)
+            label = f"<<{conn.conn_type.lower()}>>"
+        points = [(ax, ay)]
+        if conn.style == "Squared":
+            midx = (ax + bx) / 2
+            points.extend([(midx, ay), (midx, by)])
+        elif conn.style == "Custom":
+            for px, py in conn.points:
+                x = px * self.zoom
+                y = py * self.zoom
+                last = points[-1]
+                points.extend([(x, last[1]), (x, y)])
+        points.append((bx, by))
+        flat = [coord for pt in points for coord in pt]
+        self.canvas.create_line(*flat, arrow=tk.LAST, dash=dash)
+        if label:
+            mx, my = (ax + bx) / 2, (ay + by) / 2
+            self.canvas.create_text(mx, my - 10 * self.zoom, text=label)
 
     def get_object(self, oid: int) -> SysMLObject | None:
         for o in self.objects:
@@ -257,7 +365,6 @@ class SysMLDiagramWindow(tk.Toplevel):
         return None
 
     def on_close(self):
-        self.repo.delete_diagram(self.diagram_id)
         self.destroy()
 
 class SysMLObjectDialog(simpledialog.Dialog):
@@ -282,11 +389,58 @@ class SysMLObjectDialog(simpledialog.Dialog):
         key = f"{self.obj.obj_type.replace(' ', '')}Usage"
         for prop in SYSML_PROPERTIES.get(key, []):
             ttk.Label(master, text=f"{prop}:").grid(row=row, column=0, sticky="e", padx=4, pady=2)
-            var = tk.StringVar(value=self.obj.properties.get(prop, ""))
-            ttk.Entry(master, textvariable=var).grid(row=row, column=1, padx=4, pady=2)
-            self.entries[prop] = var
+            if prop == "ports":
+                self.port_list = tk.Listbox(master, height=4)
+                ports = self.obj.properties.get("ports", "").split(",")
+                for p in ports:
+                    p = p.strip()
+                    if p:
+                        self.port_list.insert(tk.END, p)
+                self.port_list.grid(row=row, column=1, padx=4, pady=2, sticky="we")
+                btnf = ttk.Frame(master)
+                btnf.grid(row=row, column=2, padx=2)
+                ttk.Button(btnf, text="Add", command=self.add_port).pack(side=tk.TOP)
+                ttk.Button(btnf, text="Remove", command=self.remove_port).pack(side=tk.TOP)
+            else:
+                var = tk.StringVar(value=self.obj.properties.get(prop, ""))
+                ttk.Entry(master, textvariable=var).grid(row=row, column=1, padx=4, pady=2)
+                self.entries[prop] = var
             row += 1
 
+        repo = SysMLRepository.get_instance()
+        if self.obj.obj_type == "Use Case":
+            diags = [d for d in repo.diagrams.values() if d.diag_type == "Activity Diagram"]
+            names = [d.name or d.diag_id for d in diags]
+            ids = {d.name or d.diag_id: d.diag_id for d in diags}
+            ttk.Label(master, text="Activity Diagram:").grid(row=row, column=0, sticky="e", padx=4, pady=2)
+            self.diag_map = ids
+            cur_id = repo.get_linked_diagram(self.obj.element_id)
+            cur_name = next((n for n, i in ids.items() if i == cur_id), "")
+            self.diagram_var = tk.StringVar(value=cur_name)
+            ttk.Combobox(master, textvariable=self.diagram_var, values=list(ids.keys())).grid(row=row, column=1, padx=4, pady=2)
+            row += 1
+        elif self.obj.obj_type == "Block":
+            diags = [d for d in repo.diagrams.values() if d.diag_type == "Internal Block Diagram"]
+            names = [d.name or d.diag_id for d in diags]
+            ids = {d.name or d.diag_id: d.diag_id for d in diags}
+            ttk.Label(master, text="Internal Block Diagram:").grid(row=row, column=0, sticky="e", padx=4, pady=2)
+            self.diag_map = ids
+            cur_id = repo.get_linked_diagram(self.obj.element_id)
+            cur_name = next((n for n, i in ids.items() if i == cur_id), "")
+            self.diagram_var = tk.StringVar(value=cur_name)
+            ttk.Combobox(master, textvariable=self.diagram_var, values=list(ids.keys())).grid(row=row, column=1, padx=4, pady=2)
+            row += 1
+
+    def add_port(self):
+        name = simpledialog.askstring("Port", "Name:", parent=self)
+        if name:
+            self.port_list.insert(tk.END, name)
+
+    def remove_port(self):
+        sel = list(self.port_list.curselection())
+        for idx in reversed(sel):
+            self.port_list.delete(idx)
+        
     def apply(self):
         self.obj.properties["name"] = self.name_var.get()
         repo = SysMLRepository.get_instance()
@@ -296,14 +450,71 @@ class SysMLObjectDialog(simpledialog.Dialog):
             self.obj.properties[prop] = var.get()
             if self.obj.element_id and self.obj.element_id in repo.elements:
                 repo.elements[self.obj.element_id].properties[prop] = var.get()
+        if hasattr(self, "port_list"):
+            ports = [self.port_list.get(i) for i in range(self.port_list.size())]
+            joined = ", ".join(ports)
+            self.obj.properties["ports"] = joined
+            if self.obj.element_id and self.obj.element_id in repo.elements:
+                repo.elements[self.obj.element_id].properties["ports"] = joined
         try:
             self.obj.width = float(self.width_var.get())
             self.obj.height = float(self.height_var.get())
         except ValueError:
             pass
+        # Update linked diagram if applicable
+        if hasattr(self, "diagram_var"):
+            name = self.diagram_var.get()
+            diag_id = self.diag_map.get(name)
+            repo.link_diagram(self.obj.element_id, diag_id)
+
+
+class ConnectionDialog(simpledialog.Dialog):
+    """Edit connection style and custom routing points."""
+
+    def __init__(self, master, connection: DiagramConnection):
+        self.connection = connection
+        super().__init__(master, title="Connection Properties")
+
+    def body(self, master):
+        ttk.Label(master, text="Style:").grid(row=0, column=0, sticky="e", padx=4, pady=4)
+        self.style_var = tk.StringVar(value=self.connection.style)
+        ttk.Combobox(master, textvariable=self.style_var,
+                     values=["Straight", "Squared", "Custom"]).grid(row=0, column=1, padx=4, pady=4)
+        ttk.Label(master, text="Points:").grid(row=1, column=0, sticky="ne", padx=4, pady=4)
+        self.point_list = tk.Listbox(master, height=4)
+        for px, py in self.connection.points:
+            self.point_list.insert(tk.END, f"{px:.1f},{py:.1f}")
+        self.point_list.grid(row=1, column=1, padx=4, pady=4, sticky="we")
+        btnf = ttk.Frame(master)
+        btnf.grid(row=1, column=2, padx=2)
+        ttk.Button(btnf, text="Add", command=self.add_point).pack(side=tk.TOP)
+        ttk.Button(btnf, text="Remove", command=self.remove_point).pack(side=tk.TOP)
+
+    def add_point(self):
+        x = simpledialog.askfloat("Point", "X:", parent=self)
+        y = simpledialog.askfloat("Point", "Y:", parent=self)
+        if x is not None and y is not None:
+            self.point_list.insert(tk.END, f"{x},{y}")
+
+    def remove_point(self):
+        sel = list(self.point_list.curselection())
+        for idx in reversed(sel):
+            self.point_list.delete(idx)
+
+    def apply(self):
+        self.connection.style = self.style_var.get()
+        pts = []
+        for i in range(self.point_list.size()):
+            txt = self.point_list.get(i)
+            try:
+                x_str, y_str = txt.split(",")
+                pts.append((float(x_str), float(y_str)))
+            except ValueError:
+                continue
+        self.connection.points = pts
 
 class UseCaseDiagramWindow(SysMLDiagramWindow):
-    def __init__(self, master):
+    def __init__(self, master, diagram_id: str | None = None):
         tools = [
             "Actor",
             "Use Case",
@@ -312,11 +523,11 @@ class UseCaseDiagramWindow(SysMLDiagramWindow):
             "Include",
             "Extend",
         ]
-        super().__init__(master, "Use Case Diagram", tools)
+        super().__init__(master, "Use Case Diagram", tools, diagram_id)
 
 
 class ActivityDiagramWindow(SysMLDiagramWindow):
-    def __init__(self, master):
+    def __init__(self, master, diagram_id: str | None = None):
         tools = [
             "Action",
             "Initial",
@@ -327,24 +538,177 @@ class ActivityDiagramWindow(SysMLDiagramWindow):
             "Join",
             "Flow",
         ]
-        super().__init__(master, "Activity Diagram", tools)
+        super().__init__(master, "Activity Diagram", tools, diagram_id)
 
 
 class BlockDiagramWindow(SysMLDiagramWindow):
-    def __init__(self, master):
+    def __init__(self, master, diagram_id: str | None = None):
         tools = [
             "Block",
             "Association",
         ]
-        super().__init__(master, "Block Diagram", tools)
+        super().__init__(master, "Block Diagram", tools, diagram_id)
 
 
 class InternalBlockDiagramWindow(SysMLDiagramWindow):
-    def __init__(self, master):
+    def __init__(self, master, diagram_id: str | None = None):
         tools = [
             "Block",
             "Part",
             "Port",
             "Connector",
         ]
-        super().__init__(master, "Internal Block Diagram", tools)
+        super().__init__(master, "Internal Block Diagram", tools, diagram_id)
+
+
+class NewDiagramDialog(simpledialog.Dialog):
+    """Dialog to create a new diagram and assign a name and type."""
+
+    def __init__(self, master):
+        self.name = ""
+        self.diag_type = "Use Case Diagram"
+        super().__init__(master, title="New Diagram")
+
+    def body(self, master):
+        ttk.Label(master, text="Name:").grid(row=0, column=0, padx=4, pady=4, sticky="e")
+        self.name_var = tk.StringVar()
+        ttk.Entry(master, textvariable=self.name_var).grid(row=0, column=1, padx=4, pady=4)
+        ttk.Label(master, text="Type:").grid(row=1, column=0, padx=4, pady=4, sticky="e")
+        self.type_var = tk.StringVar(value=self.diag_type)
+        ttk.Combobox(master, textvariable=self.type_var,
+                     values=["Use Case Diagram", "Activity Diagram", "Block Diagram", "Internal Block Diagram"]).grid(row=1, column=1, padx=4, pady=4)
+
+    def apply(self):
+        self.name = self.name_var.get()
+        self.diag_type = self.type_var.get()
+
+
+class DiagramPropertiesDialog(simpledialog.Dialog):
+    """Dialog to edit a diagram's metadata."""
+
+    def __init__(self, master, diagram: SysMLDiagram):
+        self.diagram = diagram
+        super().__init__(master, title="Diagram Properties")
+
+    def body(self, master):
+        ttk.Label(master, text="Name:").grid(row=0, column=0, sticky="e", padx=4, pady=2)
+        self.name_var = tk.StringVar(value=self.diagram.name)
+        ttk.Entry(master, textvariable=self.name_var).grid(row=0, column=1, padx=4, pady=2)
+        ttk.Label(master, text="Description:").grid(row=1, column=0, sticky="e", padx=4, pady=2)
+        self.desc_var = tk.StringVar(value=getattr(self.diagram, "description", ""))
+        ttk.Entry(master, textvariable=self.desc_var).grid(row=1, column=1, padx=4, pady=2)
+        ttk.Label(master, text="Color:").grid(row=2, column=0, sticky="e", padx=4, pady=2)
+        self.color_var = tk.StringVar(value=getattr(self.diagram, "color", "#FFFFFF"))
+        ttk.Entry(master, textvariable=self.color_var).grid(row=2, column=1, padx=4, pady=2)
+
+    def apply(self):
+        self.diagram.name = self.name_var.get()
+        self.diagram.description = self.desc_var.get()
+        self.diagram.color = self.color_var.get()
+
+
+class ArchitectureManagerDialog(tk.Toplevel):
+    """Manage packages and diagrams in a hierarchical tree."""
+
+    def __init__(self, master):
+        super().__init__(master)
+        self.title("Architecture")
+        self.repo = SysMLRepository.get_instance()
+        self.geometry("350x400")
+        self.tree = ttk.Treeview(self)
+        self.tree.pack(fill=tk.BOTH, expand=True, padx=4, pady=4)
+        btns = ttk.Frame(self)
+        btns.pack(fill=tk.X, padx=4, pady=4)
+        ttk.Button(btns, text="Open", command=self.open).pack(side=tk.LEFT, padx=2)
+        ttk.Button(btns, text="Properties", command=self.properties).pack(side=tk.LEFT, padx=2)
+        ttk.Button(btns, text="New Package", command=self.new_package).pack(side=tk.LEFT, padx=2)
+        ttk.Button(btns, text="New Diagram", command=self.new_diagram).pack(side=tk.LEFT, padx=2)
+        ttk.Button(btns, text="Delete", command=self.delete).pack(side=tk.LEFT, padx=2)
+        ttk.Button(btns, text="Close", command=self.destroy).pack(side=tk.RIGHT, padx=2)
+        self.populate()
+        self.tree.bind("<Double-1>", self.on_double)
+
+    def populate(self):
+        self.tree.delete(*self.tree.get_children())
+
+        def add_pkg(pkg_id, parent=""):
+            pkg = self.repo.elements[pkg_id]
+            node = self.tree.insert(parent, "end", iid=pkg_id, text=pkg.name or pkg_id, open=True)
+            for p in self.repo.elements.values():
+                if p.elem_type == "Package" and p.owner == pkg_id:
+                    add_pkg(p.elem_id, node)
+            for d in self.repo.diagrams.values():
+                if d.package == pkg_id:
+                    label = d.name or d.diag_id
+                    self.tree.insert(node, "end", iid=f"diag_{d.diag_id}", text=label, values=(d.diag_type,))
+
+        add_pkg(self.repo.root_package.elem_id)
+
+    def selected(self):
+        sel = self.tree.selection()
+        if sel:
+            return sel[0]
+        item = self.tree.focus()
+        return item if item else None
+
+    def open(self):
+        item = self.selected()
+        if item and item.startswith("diag_"):
+            self.open_diagram(item[5:])
+
+    def on_double(self, event):
+        item = self.tree.identify_row(event.y)
+        if item:
+            self.tree.selection_set(item)
+            if item.startswith("diag_"):
+                self.open_diagram(item[5:])
+
+    def open_diagram(self, diag_id: str):
+        diag = self.repo.diagrams.get(diag_id)
+        if not diag:
+            return
+        master = self.master if self.master else self
+        if diag.diag_type == "Use Case Diagram":
+            UseCaseDiagramWindow(master, diagram_id=diag_id)
+        elif diag.diag_type == "Activity Diagram":
+            ActivityDiagramWindow(master, diagram_id=diag_id)
+        elif diag.diag_type == "Block Diagram":
+            BlockDiagramWindow(master, diagram_id=diag_id)
+        elif diag.diag_type == "Internal Block Diagram":
+            InternalBlockDiagramWindow(master, diagram_id=diag_id)
+
+    def new_package(self):
+        item = self.selected() or self.repo.root_package.elem_id
+        if item.startswith("diag_"):
+            item = self.repo.diagrams[item[5:]].package
+        name = simpledialog.askstring("New Package", "Name:")
+        if name:
+            self.repo.create_package(name, parent=item)
+            self.populate()
+
+    def new_diagram(self):
+        item = self.selected() or self.repo.root_package.elem_id
+        if item.startswith("diag_"):
+            item = self.repo.diagrams[item[5:]].package
+        dlg = NewDiagramDialog(self)
+        if dlg.name:
+            self.repo.create_diagram(dlg.diag_type, name=dlg.name, package=item)
+            self.populate()
+
+    def delete(self):
+        item = self.selected()
+        if not item:
+            return
+        if item.startswith("diag_"):
+            self.repo.delete_diagram(item[5:])
+        else:
+            self.repo.delete_package(item)
+        self.populate()
+
+    def properties(self):
+        item = self.selected()
+        if item and item.startswith("diag_"):
+            diag = self.repo.diagrams.get(item[5:])
+            if diag:
+                DiagramPropertiesDialog(self, diag)
+                self.populate()

--- a/sysml_spec.py
+++ b/sysml_spec.py
@@ -26,3 +26,12 @@ def load_sysml_properties():
     return props
 
 SYSML_PROPERTIES = load_sysml_properties()
+if 'BlockUsage' not in SYSML_PROPERTIES:
+    SYSML_PROPERTIES['BlockUsage'] = [
+        'valueProperties',
+        'partProperties',
+        'referenceProperties',
+        'ports',
+        'constraintProperties',
+        'operations',
+    ]

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -54,5 +54,40 @@ class RepositoryTests(unittest.TestCase):
         self.assertIn(diag.diag_id, new_repo.diagrams)
         self.assertIn(actor.elem_id, new_repo.diagrams[diag.diag_id].elements)
 
+    def test_element_diagram_linking(self):
+        uc = self.repo.create_element("Use Case")
+        ad = self.repo.create_diagram("Activity Diagram", name="AD1")
+        self.repo.link_diagram(uc.elem_id, ad.diag_id)
+        linked = self.repo.get_linked_diagram(uc.elem_id)
+        self.assertEqual(linked, ad.diag_id)
+        path = "repo_link.json"
+        self.repo.save(path)
+        SysMLRepository._instance = None
+        new_repo = SysMLRepository.get_instance()
+        new_repo.load(path)
+        os.remove(path)
+        self.assertEqual(new_repo.get_linked_diagram(uc.elem_id), ad.diag_id)
+
+    def test_diagram_package(self):
+        pkg = self.repo.create_package("PkgA")
+        diag = self.repo.create_diagram("Use Case Diagram", name="UC2", package=pkg.elem_id)
+        self.assertEqual(diag.package, pkg.elem_id)
+        path = "repo_pkg.json"
+        self.repo.save(path)
+        SysMLRepository._instance = None
+        new_repo = SysMLRepository.get_instance()
+        new_repo.load(path)
+        os.remove(path)
+        self.assertEqual(new_repo.diagrams[diag.diag_id].package, pkg.elem_id)
+
+    def test_delete_package_reassign(self):
+        pkg = self.repo.create_package("P1")
+        sub = self.repo.create_package("Sub", parent=pkg.elem_id)
+        blk = self.repo.create_element("Block", owner=sub.elem_id)
+        diag = self.repo.create_diagram("Use Case Diagram", package=sub.elem_id)
+        self.repo.delete_package(sub.elem_id)
+        self.assertEqual(self.repo.elements[blk.elem_id].owner, pkg.elem_id)
+        self.assertEqual(self.repo.diagrams[diag.diag_id].package, pkg.elem_id)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- allow selecting tree items in the architecture manager more reliably
- double-click opens the clicked diagram and uses the main window as parent
- diagram windows can be reopened after closing

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68824b1fe7fc8325be7baa822a8b5b7e