### PR TITLE
Improve FI2TC/TC2FI analysis dialogs

### DIFF
--- a/toolboxes.py
+++ b/toolboxes.py
@@ -431,7 +431,7 @@ class FI2TCWindow(tk.Toplevel):
         tree_frame = ttk.Frame(self)
         tree_frame.pack(fill=tk.BOTH, expand=True)
         style = ttk.Style(self)
-        style.configure("FI2TC.Treeview", rowheight=60)
+        style.configure("FI2TC.Treeview", rowheight=80)
         self.tree = ttk.Treeview(
             tree_frame, columns=self.COLS, show="headings", style="FI2TC.Treeview"
         )
@@ -487,48 +487,48 @@ class FI2TCWindow(tk.Toplevel):
                     w["values"] = func_opts
 
             for col in self.parent_win.COLS:
-                ttk.Label(master, text=col.replace("_", " ").title()).grid(row=r, column=0, sticky="e")
+                ttk.Label(master, text=col.replace("_", " ").title()).grid(row=r, column=0, sticky="e", padx=5, pady=2)
                 if col == "triggering_condition":
                     var = tk.StringVar(value=self.data.get(col, ""))
                     cb = ttk.Combobox(master, textvariable=var, values=tc_names, state="readonly")
-                    cb.grid(row=r, column=1)
+                    cb.grid(row=r, column=1, padx=5, pady=2)
                     self.widgets[col] = var
                 elif col == "insufficiency":
                     var = tk.StringVar(value=self.data.get(col, ""))
                     cb = ttk.Combobox(master, textvariable=var, values=fi_names, state="readonly")
-                    cb.grid(row=r, column=1)
+                    cb.grid(row=r, column=1, padx=5, pady=2)
                     self.widgets[col] = var
                 elif col == "system_function":
                     var = tk.StringVar(value=self.data.get(col, ""))
                     cb = ttk.Combobox(master, textvariable=var, values=func_names, state="readonly")
-                    cb.grid(row=r, column=1)
+                    cb.grid(row=r, column=1, padx=5, pady=2)
                     self.widgets[col] = var
                     self.widgets["system_function_widget"] = cb
                 elif col == "allocation":
                     var = tk.StringVar(value=self.data.get(col, ""))
                     cb = ttk.Combobox(master, textvariable=var, values=comp_names, state="readonly")
-                    cb.grid(row=r, column=1)
+                    cb.grid(row=r, column=1, padx=5, pady=2)
                     cb.bind("<<ComboboxSelected>>", refresh_funcs)
                     self.widgets[col] = var
                 elif col == "scene":
                     var = tk.StringVar(value=self.data.get(col, ""))
                     cb = ttk.Combobox(master, textvariable=var, values=scene_names, state="readonly")
-                    cb.grid(row=r, column=1)
+                    cb.grid(row=r, column=1, padx=5, pady=2)
                     self.widgets[col] = var
                 elif col == "scenario":
                     var = tk.StringVar(value=self.data.get(col, ""))
                     cb = ttk.Combobox(master, textvariable=var, values=scen_names, state="readonly")
-                    cb.grid(row=r, column=1)
+                    cb.grid(row=r, column=1, padx=5, pady=2)
                     self.widgets[col] = var
                 elif col == "severity":
                     var = tk.StringVar(value=self.data.get(col, ""))
                     cb = ttk.Combobox(master, textvariable=var, values=["1", "2", "3"], state="readonly")
-                    cb.grid(row=r, column=1)
+                    cb.grid(row=r, column=1, padx=5, pady=2)
                     self.widgets[col] = var
                 else:
-                    txt = tk.Text(master, width=30, height=3)
+                    txt = tk.Text(master, width=25, height=2, wrap="word")
                     txt.insert("1.0", self.data.get(col, ""))
-                    txt.grid(row=r, column=1)
+                    txt.grid(row=r, column=1, padx=5, pady=2)
                     self.widgets[col] = txt
                 r += 1
             refresh_funcs()
@@ -1080,7 +1080,7 @@ class TC2FIWindow(tk.Toplevel):
         tree_frame = ttk.Frame(self)
         tree_frame.pack(fill=tk.BOTH, expand=True)
         style = ttk.Style(self)
-        style.configure("TC2FI.Treeview", rowheight=60)
+        style.configure("TC2FI.Treeview", rowheight=80)
         self.tree = ttk.Treeview(
             tree_frame, columns=self.COLS, show="headings", style="TC2FI.Treeview"
         )
@@ -1137,48 +1137,48 @@ class TC2FIWindow(tk.Toplevel):
                     w["values"] = opts
 
             for col in TC2FIWindow.COLS:
-                ttk.Label(master, text=col.replace("_", " ").title()).grid(row=r, column=0, sticky="e")
+                ttk.Label(master, text=col.replace("_", " ").title()).grid(row=r, column=0, sticky="e", padx=5, pady=2)
                 if col == "functional_insufficiency":
                     var = tk.StringVar(value=self.data.get(col, ""))
                     cb = ttk.Combobox(master, textvariable=var, values=fi_names, state="readonly")
-                    cb.grid(row=r, column=1)
+                    cb.grid(row=r, column=1, padx=5, pady=2)
                     self.widgets[col] = var
                 elif col == "triggering_condition":
                     var = tk.StringVar(value=self.data.get(col, ""))
                     cb = ttk.Combobox(master, textvariable=var, values=tc_names, state="readonly")
-                    cb.grid(row=r, column=1)
+                    cb.grid(row=r, column=1, padx=5, pady=2)
                     self.widgets[col] = var
                 elif col == "impacted_function":
                     var = tk.StringVar(value=self.data.get(col, ""))
                     cb = ttk.Combobox(master, textvariable=var, values=func_names, state="readonly")
-                    cb.grid(row=r, column=1)
+                    cb.grid(row=r, column=1, padx=5, pady=2)
                     self.widgets[col] = var
                     self.widgets["impacted_function_widget"] = cb
                 elif col == "arch_elements":
                     var = tk.StringVar(value=self.data.get(col, ""))
                     cb = ttk.Combobox(master, textvariable=var, values=comp_names, state="readonly")
-                    cb.grid(row=r, column=1)
+                    cb.grid(row=r, column=1, padx=5, pady=2)
                     cb.bind("<<ComboboxSelected>>", refresh_funcs)
                     self.widgets[col] = var
                 elif col == "scene":
                     var = tk.StringVar(value=self.data.get(col, ""))
                     cb = ttk.Combobox(master, textvariable=var, values=scene_names, state="readonly")
-                    cb.grid(row=r, column=1)
+                    cb.grid(row=r, column=1, padx=5, pady=2)
                     self.widgets[col] = var
                 elif col == "scenario":
                     var = tk.StringVar(value=self.data.get(col, ""))
                     cb = ttk.Combobox(master, textvariable=var, values=scen_names, state="readonly")
-                    cb.grid(row=r, column=1)
+                    cb.grid(row=r, column=1, padx=5, pady=2)
                     self.widgets[col] = var
                 elif col == "severity":
                     var = tk.StringVar(value=self.data.get(col, ""))
                     cb = ttk.Combobox(master, textvariable=var, values=["1", "2", "3"], state="readonly")
-                    cb.grid(row=r, column=1)
+                    cb.grid(row=r, column=1, padx=5, pady=2)
                     self.widgets[col] = var
                 else:
-                    txt = tk.Text(master, width=30, height=3)
+                    txt = tk.Text(master, width=25, height=2, wrap="word")
                     txt.insert("1.0", self.data.get(col, ""))
-                    txt.grid(row=r, column=1)
+                    txt.grid(row=r, column=1, padx=5, pady=2)
                     self.widgets[col] = txt
                 r += 1
             refresh_funcs()


### PR DESCRIPTION
## Summary
- tweak FI2TC and TC2FI analysis dialogs
  - increase table row height for multiline content
  - shrink text fields and add padding

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6882e16edbb08325b42763a5b6795dca