### PR TITLE
Enable resizing of architecture diagram objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AutoSafeguard Analyzer
 
-This repository contains a graphical fault tree analysis tool. The latest update adds a **Review Toolbox** supporting peer and joint review workflows. The explorer pane now includes an **Analyses** tab listing all FMEAs, FMEDAs, HAZOPs, HARAs and architecture diagrams so they can be opened directly.
+This repository contains a graphical fault tree analysis tool. The latest update adds a **Review Toolbox** supporting peer and joint review workflows. The explorer pane now includes an **Analyses** tab listing all FMEAs, FMEDAs, HAZOPs, HARAs and architecture diagrams so they can be opened directly. Objects drawn on these diagrams can now be resized by editing their width and height values. Fork and join bars keep a constant thickness and only their length may be changed.
 
 ## Review Toolbox
 


### PR DESCRIPTION
## Summary
- allow setting object dimensions on creation for system boundary, decisions, forks and more
- draw shapes using stored widths/heights and keep fork thickness fixed
- skip height entry for fork/join in the object dialog
- document that architecture objects can now be resized

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6882f13239dc83258e14811bef83bde3