### PR TITLE
Add reliability attributes to SysML elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,16 @@ Additional datasheet parameters such as diode forward voltage or MOSFET
 `RDS(on)` can be entered when configuring components to better document the
 parts used in the analysis.
 
+### BOM Integration with SysML Diagrams
+
+Blocks in block diagrams may reference circuits defined in a saved BOM via the
+new **circuit** property while parts reference individual components using the
+**component** property.  Both element types also provide **fit**,
+**qualification** and **failureModes** attributes.  Entering values for these
+fields shows them in a *Reliability* compartment for blocks or as additional
+lines beneath parts so FIT rates and qualification information remain visible in
+the architecture model.
+
 ### HAZOP Analysis
 
 The **HAZOP Analysis** window lets you list system functions with one or more

--- a/architecture.py
+++ b/architecture.py
@@ -425,6 +425,18 @@ class SysMLDiagramWindow(tk.Toplevel):
                 ("Operations", obj.properties.get("operations", "")),
                 ("Constraints", obj.properties.get("constraintProperties", "")),
                 ("Ports", obj.properties.get("ports", "")),
+                (
+                    "Reliability",
+                    " ".join(
+                        f"{label}={obj.properties.get(key,'')}"
+                        for label, key in (
+                            ("FIT", "fit"),
+                            ("Qual", "qualification"),
+                            ("FM", "failureModes"),
+                        )
+                        if obj.properties.get(key, "")
+                    ),
+                ),
             ]
             cy = top + 20 * self.zoom
             for label, text in compartments:
@@ -469,6 +481,18 @@ class SysMLDiagramWindow(tk.Toplevel):
                 val = obj.properties.get(prop)
                 if val:
                     label_lines.append(f"{prop}: {val}")
+            if obj.obj_type == "Part":
+                rel_items = []
+                for lbl, key in (
+                    ("FIT", "fit"),
+                    ("Qual", "qualification"),
+                    ("FM", "failureModes"),
+                ):
+                    val = obj.properties.get(key)
+                    if val:
+                        rel_items.append(f"{lbl}: {val}")
+                if rel_items:
+                    label_lines.extend(rel_items)
             self.canvas.create_text(x, y, text="\n".join(label_lines), anchor="center")
 
     def draw_connection(self, a: SysMLObject, b: SysMLObject, conn: DiagramConnection):

--- a/sysml_spec.py
+++ b/sysml_spec.py
@@ -40,3 +40,21 @@ if 'PortUsage' not in SYSML_PROPERTIES:
 for p in ('direction', 'flow'):
     if p not in SYSML_PROPERTIES['PortUsage']:
         SYSML_PROPERTIES['PortUsage'].append(p)
+
+# ----------------------------------------------------------------------
+# Additional properties for reliability annotations
+# ----------------------------------------------------------------------
+# Blocks can represent circuits while parts map to components. Include
+# dedicated attributes to reference BOM items and store FIT, qualification
+# and failure mode details so they can be displayed in diagrams.
+
+SYSML_PROPERTIES.setdefault('BlockUsage', [])
+SYSML_PROPERTIES.setdefault('PartUsage', [])
+
+for prop in ('circuit', 'fit', 'qualification', 'failureModes'):
+    if prop not in SYSML_PROPERTIES['BlockUsage']:
+        SYSML_PROPERTIES['BlockUsage'].append(prop)
+
+for prop in ('component', 'fit', 'qualification', 'failureModes'):
+    if prop not in SYSML_PROPERTIES['PartUsage']:
+        SYSML_PROPERTIES['PartUsage'].append(prop)


### PR DESCRIPTION
## Summary
- allow Blocks to reference circuits and Parts to reference components from a BOM
- display FIT, qualification and failure modes
- document how to use BOM data in SysML diagrams

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6882f1edf5348325a00b3856c0a2587a