### PR TITLE
Add reliability data selection for SysML elements

### DIFF
--- a/AutoSafeguard.py
+++ b/AutoSafeguard.py
@@ -10596,27 +10596,27 @@ class FaultTreeApp:
         return _close
 
     def open_use_case_diagram(self):
-        win = UseCaseDiagramWindow(self.root)
+        win = UseCaseDiagramWindow(self.root, self)
         win.protocol("WM_DELETE_WINDOW", self._register_close(win, self.use_case_windows))
         self.use_case_windows.append(win)
 
     def open_activity_diagram(self):
-        win = ActivityDiagramWindow(self.root)
+        win = ActivityDiagramWindow(self.root, self)
         win.protocol("WM_DELETE_WINDOW", self._register_close(win, self.activity_windows))
         self.activity_windows.append(win)
 
     def open_block_diagram(self):
-        win = BlockDiagramWindow(self.root)
+        win = BlockDiagramWindow(self.root, self)
         win.protocol("WM_DELETE_WINDOW", self._register_close(win, self.block_windows))
         self.block_windows.append(win)
 
     def open_internal_block_diagram(self):
-        win = InternalBlockDiagramWindow(self.root)
+        win = InternalBlockDiagramWindow(self.root, self)
         win.protocol("WM_DELETE_WINDOW", self._register_close(win, self.ibd_windows))
         self.ibd_windows.append(win)
 
     def manage_architecture(self):
-        ArchitectureManagerDialog(self.root)
+        ArchitectureManagerDialog(self.root, self)
         
     def copy_node(self):
         if self.selected_node and self.selected_node != self.root_node:

--- a/README.md
+++ b/README.md
@@ -69,6 +69,19 @@ Additional datasheet parameters such as diode forward voltage or MOSFET
 `RDS(on)` can be entered when configuring components to better document the
 parts used in the analysis.
 
+### BOM Integration with SysML Diagrams
+
+Blocks in block diagrams may reference circuits defined in a saved BOM via the
+new **circuit** property while parts reference individual components using the
+**component** property.  Both element types also provide **fit**,
+**qualification** and **failureModes** attributes.  Entering values for these
+fields shows them in a *Reliability* compartment for blocks or as additional
+lines beneath parts so FIT rates and qualification information remain visible in
+the architecture model. When editing a block or part you can now pick from
+drop-down lists containing all circuits or components from saved reliability
+analyses. Selecting an item automatically fills in its FIT rate, qualification
+certificate and any failure modes found in FMEA tables.
+
 ### HAZOP Analysis
 
 The **HAZOP Analysis** window lets you list system functions with one or more

--- a/sysml_spec.py
+++ b/sysml_spec.py
@@ -40,3 +40,21 @@ if 'PortUsage' not in SYSML_PROPERTIES:
 for p in ('direction', 'flow'):
     if p not in SYSML_PROPERTIES['PortUsage']:
         SYSML_PROPERTIES['PortUsage'].append(p)
+
+# ----------------------------------------------------------------------
+# Additional properties for reliability annotations
+# ----------------------------------------------------------------------
+# Blocks can represent circuits while parts map to components. Include
+# dedicated attributes to reference BOM items and store FIT, qualification
+# and failure mode details so they can be displayed in diagrams.
+
+SYSML_PROPERTIES.setdefault('BlockUsage', [])
+SYSML_PROPERTIES.setdefault('PartUsage', [])
+
+for prop in ('circuit', 'fit', 'qualification', 'failureModes'):
+    if prop not in SYSML_PROPERTIES['BlockUsage']:
+        SYSML_PROPERTIES['BlockUsage'].append(prop)
+
+for prop in ('component', 'fit', 'qualification', 'failureModes'):
+    if prop not in SYSML_PROPERTIES['PartUsage']:
+        SYSML_PROPERTIES['PartUsage'].append(prop)


### PR DESCRIPTION
## Summary
- allow SysML diagram windows to access the main app
- open architecture dialogs with the app so reliability analyses are available
- provide combo boxes for choosing circuits or components when editing blocks and parts
- auto-populate FIT, qualification and failure modes from reliability analyses
- document new drop-down behaviour

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6882f1edf5348325a00b3856c0a2587a