### PR TITLE
Add Use Case definition selector

### DIFF
--- a/architecture.py
+++ b/architecture.py
@@ -720,6 +720,16 @@ class SysMLObjectDialog(simpledialog.Dialog):
                 var = tk.StringVar(value=self.obj.properties.get(prop, "in"))
                 ttk.Combobox(master, textvariable=var, values=["in", "out", "inout"]).grid(row=row, column=1, padx=4, pady=2)
                 self.entries[prop] = var
+            elif self.obj.obj_type == "Use Case" and prop == "useCaseDefinition":
+                repo = SysMLRepository.get_instance()
+                defs = [e for e in repo.elements.values() if e.elem_type == "Use Case"]
+                idmap = {d.name or d.elem_id: d.elem_id for d in defs}
+                self.ucdef_map = idmap
+                cur_id = self.obj.properties.get(prop, "")
+                cur_name = next((n for n, i in idmap.items() if i == cur_id), "")
+                var = tk.StringVar(value=cur_name)
+                ttk.Combobox(master, textvariable=var, values=list(idmap.keys())).grid(row=row, column=1, padx=4, pady=2)
+                self.entries[prop] = var
             else:
                 var = tk.StringVar(value=self.obj.properties.get(prop, ""))
                 ttk.Entry(master, textvariable=var).grid(row=row, column=1, padx=4, pady=2)
@@ -827,6 +837,13 @@ class SysMLObjectDialog(simpledialog.Dialog):
                 self.obj.properties["definition"] = def_id
                 if self.obj.element_id and self.obj.element_id in repo.elements:
                     repo.elements[self.obj.element_id].properties["definition"] = def_id
+        if hasattr(self, "ucdef_var"):
+            name = self.ucdef_var.get()
+            def_id = self.ucdef_map.get(name)
+            if def_id:
+                self.obj.properties["useCaseDefinition"] = def_id
+                if self.obj.element_id and self.obj.element_id in repo.elements:
+                    repo.elements[self.obj.element_id].properties["useCaseDefinition"] = def_id
                     
 class ConnectionDialog(simpledialog.Dialog):
     """Edit connection style and custom routing points."""


### PR DESCRIPTION
## Summary
- support selecting a UseCaseDefinition in the Use Case object dialog
- persist chosen definition in the repository

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6882f6e9f04c8325b0f64898aaccd66b