### PR TITLE
UI enhancements for architecture diagrams

### DIFF
--- a/sysml_spec.py
+++ b/sysml_spec.py
@@ -40,6 +40,9 @@ if 'PortUsage' not in SYSML_PROPERTIES:
 for p in ('direction', 'flow'):
     if p not in SYSML_PROPERTIES['PortUsage']:
         SYSML_PROPERTIES['PortUsage'].append(p)
+for p in ('labelX', 'labelY'):
+    if p not in SYSML_PROPERTIES['PortUsage']:
+        SYSML_PROPERTIES['PortUsage'].append(p)
 
 # ----------------------------------------------------------------------
 # Additional properties for reliability annotations


### PR DESCRIPTION
## Summary
- rename architecture window to "Architecture Explorer"
- avoid duplicate listing of activity elements in explorer
- simplify use case properties and remove activity diagram link
- change use case diagram tools
- draw system boundary label at top-left
- make block FIT and qualification read-only
- allow list editing of failure modes
- improve port drawing and movement with part
- add label position properties for ports
- fix explorer population after filtering bug

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6882fd791958832581198e057d11bb14