### PR TITLE
Fix duplicate items in architecture explorer

### DIFF
--- a/architecture.py
+++ b/architecture.py
@@ -1166,7 +1166,11 @@ class ArchitectureManagerDialog(tk.Toplevel):
                 if p.elem_type == "Package" and p.owner == pkg_id:
                     add_pkg(p.elem_id, node)
             for e in self.repo.elements.values():
-                if e.owner == pkg_id and e.elem_type != "Package":
+                if (
+                    e.owner == pkg_id
+                    and e.elem_type != "Package"
+                    and e.name
+                ):
                     add_elem(e.elem_id, node)
             for d in self.repo.diagrams.values():
                 if d.package == pkg_id:


### PR DESCRIPTION
## Summary
- skip elements without names when populating the architecture explorer

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688303cb060883259e56029632255fc6