### PR TITLE
Fix HAZOP function list

### DIFF
--- a/sysml_repository.py
+++ b/sysml_repository.py
@@ -199,17 +199,23 @@ class SysMLRepository:
         """Return all action names and activity diagram names."""
         names = []
         for diag in self.diagrams.values():
-            if diag.diag_type == "Activity Diagram":
-                if diag.name:
-                    names.append(diag.name)
-                for obj in diag.objects:
-                    typ = obj.get("obj_type") or obj.get("type")
-                    if typ in ("Action Usage", "Action"):
-                        name = obj.get("properties", {}).get("name", "")
-                        elem_id = obj.get("element_id")
-                        if not name and elem_id in self.elements:
-                            name = self.elements[elem_id].name
-                        if name:
-                            names.append(name)
+            if diag.diag_type != "Activity Diagram":
+                continue
+            if diag.name:
+                names.append(diag.name)
+            for obj in diag.objects:
+                typ = obj.get("obj_type") or obj.get("type")
+                if typ in ("Action Usage", "Action"):
+                    name = obj.get("properties", {}).get("name", "")
+                    elem_id = obj.get("element_id")
+                    if not name and elem_id in self.elements:
+                        name = self.elements[elem_id].name
+                    if name:
+                        names.append(name)
+            for elem_id in getattr(diag, "elements", []):
+                elem = self.elements.get(elem_id)
+                if elem and elem.elem_type in ("Action Usage", "Action"):
+                    if elem.name:
+                        names.append(elem.name)
         return sorted(set(n for n in names if n))
 

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -24,5 +24,13 @@ class ActionNameTests(unittest.TestCase):
         self.assertIn("MainFlow", names)
         self.assertIn("DoThing", names)
 
+    def test_activity_actions_from_elements(self):
+        diag = self.repo.create_diagram("Activity Diagram", name="Flow")
+        act = self.repo.create_element("Action Usage", name="Act")
+        self.repo.add_element_to_diagram(diag.diag_id, act.elem_id)
+        names = self.repo.get_activity_actions()
+        self.assertIn("Flow", names)
+        self.assertIn("Act", names)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- ensure `get_activity_actions` also collects action names from diagram elements
- test that actions are found even if only element IDs are present

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68830c79d59483258956d5590dd845ef