### PR TITLE
Fix connection drawing UX

### DIFF
--- a/architecture.py
+++ b/architecture.py
@@ -79,6 +79,7 @@ class SysMLDiagramWindow(tk.Toplevel):
         self.clipboard: SysMLObject | None = None
         self.resizing_obj: SysMLObject | None = None
         self.resize_edge: str | None = None
+        self.temp_line_end: tuple[float, float] | None = None
 
         self.toolbox = ttk.Frame(self)
         self.toolbox.pack(side=tk.LEFT, fill=tk.Y)
@@ -99,6 +100,7 @@ class SysMLDiagramWindow(tk.Toplevel):
         self.canvas.bind("<Double-Button-1>", self.on_double_click)
         self.canvas.bind("<ButtonPress-3>", self.on_rc_press)
         self.canvas.bind("<B3-Motion>", self.on_rc_drag)
+        self.canvas.bind("<Motion>", self.on_mouse_move)
         self.canvas.bind("<Control-MouseWheel>", self.on_ctrl_mousewheel)
         self.bind("<Control-c>", self.copy_selected)
         self.bind("<Control-x>", self.cut_selected)
@@ -110,6 +112,8 @@ class SysMLDiagramWindow(tk.Toplevel):
     def select_tool(self, tool):
         self.current_tool = tool
         self.start = None
+        self.temp_line_end = None
+        self.selected_obj = None
         cursor = "arrow"
         if tool != "Select":
             cursor = "crosshair" if tool in (
@@ -134,6 +138,9 @@ class SysMLDiagramWindow(tk.Toplevel):
             if self.start is None:
                 if obj:
                     self.start = obj
+                    self.selected_obj = obj
+                    self.temp_line_end = (x, y)
+                    self.redraw()
             else:
                 if obj and obj != self.start:
                     conn = DiagramConnection(self.start.obj_id, obj.obj_id, t)
@@ -143,8 +150,11 @@ class SysMLDiagramWindow(tk.Toplevel):
                     if src_id and dst_id:
                         rel = self.repo.create_relationship(t, src_id, dst_id)
                         self.repo.add_relationship_to_diagram(self.diagram_id, rel.rel_id)
+                    self._sync_to_repository()
                     ConnectionDialog(self, conn)
                 self.start = None
+                self.temp_line_end = None
+                self.selected_obj = None
                 self.redraw()
         elif t and t != "Select":
             pkg = self.repo.diagrams[self.diagram_id].package
@@ -179,6 +189,7 @@ class SysMLDiagramWindow(tk.Toplevel):
                 new_obj.properties.setdefault("labelY", "-8")
             element.properties.update(new_obj.properties)
             self.objects.append(new_obj)
+            self._sync_to_repository()
             self.redraw()
         else:
             if obj:
@@ -202,6 +213,18 @@ class SysMLDiagramWindow(tk.Toplevel):
                 self.redraw()
 
     def on_left_drag(self, event):
+        if self.start and self.current_tool in (
+            "Association",
+            "Include",
+            "Extend",
+            "Flow",
+            "Connector",
+        ):
+            x = self.canvas.canvasx(event.x)
+            y = self.canvas.canvasy(event.y)
+            self.temp_line_end = (x, y)
+            self.redraw()
+            return
         if not self.selected_obj:
             return
         x = self.canvas.canvasx(event.x)
@@ -237,11 +260,48 @@ class SysMLDiagramWindow(tk.Toplevel):
                         p.y += dy
                         self.snap_port_to_parent(p, self.selected_obj)
         self.redraw()
+        self._sync_to_repository()
 
-    def on_left_release(self, _event):
+    def on_left_release(self, event):
+        if self.start and self.current_tool in (
+            "Association",
+            "Include",
+            "Extend",
+            "Flow",
+            "Connector",
+        ):
+            x = self.canvas.canvasx(event.x)
+            y = self.canvas.canvasy(event.y)
+            obj = self.find_object(x, y)
+            if obj and obj != self.start:
+                conn = DiagramConnection(self.start.obj_id, obj.obj_id, self.current_tool)
+                self.connections.append(conn)
+                if self.start.element_id and obj.element_id:
+                    rel = self.repo.create_relationship(
+                        self.current_tool, self.start.element_id, obj.element_id
+                    )
+                    self.repo.add_relationship_to_diagram(self.diagram_id, rel.rel_id)
+                self._sync_to_repository()
+                ConnectionDialog(self, conn)
         self.start = None
+        self.temp_line_end = None
+        self.selected_obj = None
         self.resizing_obj = None
         self.resize_edge = None
+        self.redraw()
+
+    def on_mouse_move(self, event):
+        if self.start and self.current_tool in (
+            "Association",
+            "Include",
+            "Extend",
+            "Flow",
+            "Connector",
+        ):
+            x = self.canvas.canvasx(event.x)
+            y = self.canvas.canvasy(event.y)
+            self.temp_line_end = (x, y)
+            self.redraw()
 
     def on_double_click(self, event):
         x = self.canvas.canvasx(event.x)
@@ -459,6 +519,20 @@ class SysMLDiagramWindow(tk.Toplevel):
             dst = self.get_object(conn.dst)
             if src and dst:
                 self.draw_connection(src, dst, conn)
+        if (
+            self.start
+            and self.temp_line_end
+            and self.current_tool in (
+                "Association",
+                "Include",
+                "Extend",
+                "Flow",
+                "Connector",
+            )
+        ):
+            sx, sy = self.edge_point(self.start, *self.temp_line_end)
+            ex, ey = self.temp_line_end
+            self.canvas.create_line(sx, sy, ex, ey, dash=(2, 2), arrow=tk.LAST)
         self.canvas.config(scrollregion=self.canvas.bbox("all"))
 
     def draw_object(self, obj: SysMLObject):
@@ -668,6 +742,7 @@ class SysMLDiagramWindow(tk.Toplevel):
             self.clipboard = copy.deepcopy(self.selected_obj)
             self.remove_object(self.selected_obj)
             self.selected_obj = None
+            self._sync_to_repository()
             self.redraw()
 
     def paste_selected(self, _event=None):
@@ -682,12 +757,14 @@ class SysMLDiagramWindow(tk.Toplevel):
             if diag and new_obj.element_id and new_obj.element_id not in diag.elements:
                 diag.elements.append(new_obj.element_id)
             self.selected_obj = new_obj
+            self._sync_to_repository()
             self.redraw()
 
     def delete_selected(self, _event=None):
         if self.selected_obj:
             self.remove_object(self.selected_obj)
             self.selected_obj = None
+            self._sync_to_repository()
             self.redraw()
 
     def remove_object(self, obj: SysMLObject) -> None:
@@ -697,12 +774,17 @@ class SysMLDiagramWindow(tk.Toplevel):
         diag = self.repo.diagrams.get(self.diagram_id)
         if diag and obj.element_id in diag.elements:
             diag.elements.remove(obj.element_id)
+        self._sync_to_repository()
 
-    def on_close(self):
+    def _sync_to_repository(self) -> None:
+        """Persist current objects and connections back to the repository."""
         diag = self.repo.diagrams.get(self.diagram_id)
         if diag:
             diag.objects = [obj.__dict__ for obj in self.objects]
             diag.connections = [conn.__dict__ for conn in self.connections]
+
+    def on_close(self):
+        self._sync_to_repository()
         self.destroy()
 
 class SysMLObjectDialog(simpledialog.Dialog):
@@ -1071,6 +1153,8 @@ class ConnectionDialog(simpledialog.Dialog):
             except ValueError:
                 continue
         self.connection.points = pts
+        if hasattr(self.master, "_sync_to_repository"):
+            self.master._sync_to_repository()
 
 class UseCaseDiagramWindow(SysMLDiagramWindow):
     def __init__(self, master, app, diagram_id: str | None = None):

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -146,5 +146,28 @@ class RepositoryTests(unittest.TestCase):
         obj = new_repo.diagrams[diag.diag_id].objects[0]
         self.assertEqual(obj.get("requirements")[0]["id"], "REQ1")
 
+    def test_connection_persistence(self):
+        diag = self.repo.create_diagram("Block Diagram", name="BD")
+        a = self.repo.create_element("Block", name="A")
+        b = self.repo.create_element("Block", name="B")
+        self.repo.add_element_to_diagram(diag.diag_id, a.elem_id)
+        self.repo.add_element_to_diagram(diag.diag_id, b.elem_id)
+        diag.objects = [
+            {"obj_id": 1, "obj_type": "Block", "x": 0, "y": 0, "element_id": a.elem_id, "width": 80.0, "height": 40.0},
+            {"obj_id": 2, "obj_type": "Block", "x": 100, "y": 0, "element_id": b.elem_id, "width": 80.0, "height": 40.0},
+        ]
+        diag.connections = [
+            {"src": 1, "dst": 2, "conn_type": "Association", "style": "Straight", "points": []}
+        ]
+        path = "repo_conn.json"
+        self.repo.save(path)
+        SysMLRepository._instance = None
+        new_repo = SysMLRepository.get_instance()
+        new_repo.load(path)
+        os.remove(path)
+        nd = new_repo.diagrams[diag.diag_id]
+        self.assertEqual(len(nd.connections), 1)
+        self.assertEqual(nd.connections[0]["conn_type"], "Association")
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- preview connections as the cursor moves
- reset highlights when switching tools or releasing the mouse
- allow connection start objects to show a dashed line while choosing a target
- support drag-to-connect without moving the object

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68830bc2956883258801863cab150ffa