### PR TITLE
Fix circuit list refresh in block diagram

### DIFF
--- a/architecture.py
+++ b/architecture.py
@@ -887,10 +887,17 @@ class SysMLObjectDialog(simpledialog.Dialog):
                 ttk.Label(frame, text=", ".join(targets)).grid(row=row, column=1, sticky="w", padx=4, pady=2)
             elif prop == "circuit" and app:
                 circuits = [
-                    c for ra in getattr(app, 'reliability_analyses', [])
-                    for c in ra.components if c.comp_type == 'circuit'
+                    c
+                    for ra in getattr(app, 'reliability_analyses', [])
+                    for c in ra.components
+                    if c.comp_type == "circuit"
                 ]
-                names = [c.name for c in circuits]
+                circuits.extend(
+                    c
+                    for c in getattr(app, "reliability_components", [])
+                    if c.comp_type == "circuit"
+                )
+                names = list({c.name for c in circuits})
                 var = tk.StringVar(value=self.obj.properties.get(prop, ""))
                 cb = ttk.Combobox(frame, textvariable=var, values=names, state="readonly")
                 cb.grid(row=row, column=1, padx=4, pady=2)
@@ -919,10 +926,17 @@ class SysMLObjectDialog(simpledialog.Dialog):
                 cb.bind("<<ComboboxSelected>>", sync_circuit)
             elif prop == "component" and app:
                 comps = [
-                    c for ra in getattr(app, 'reliability_analyses', [])
-                    for c in ra.components if c.comp_type != 'circuit'
+                    c
+                    for ra in getattr(app, 'reliability_analyses', [])
+                    for c in ra.components
+                    if c.comp_type != "circuit"
                 ]
-                names = [c.name for c in comps]
+                comps.extend(
+                    c
+                    for c in getattr(app, "reliability_components", [])
+                    if c.comp_type != "circuit"
+                )
+                names = list({c.name for c in comps})
                 var = tk.StringVar(value=self.obj.properties.get(prop, ""))
                 cb = ttk.Combobox(frame, textvariable=var, values=names, state="readonly")
                 cb.grid(row=row, column=1, padx=4, pady=2)

--- a/toolboxes.py
+++ b/toolboxes.py
@@ -198,6 +198,8 @@ class ReliabilityWindow(tk.Toplevel):
                 ),
             )
         self.profile_combo.config(values=[mp.name for mp in self.app.mission_profiles])
+        # keep application level components updated so property dialogs see them
+        self.app.reliability_components = list(self.components)
 
     def load_csv(self):
         path = filedialog.askopenfilename(filetypes=[("CSV", "*.csv")])


### PR DESCRIPTION
## Summary
- include unsaved reliability components when populating circuit/component comboboxes
- keep `reliability_components` synchronized with the Reliability Analysis window

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6883132924b48325872508b1a773f209