### PR TITLE
Ensure SysML repository persists in model files

### DIFF
--- a/AutoSafeguard.py
+++ b/AutoSafeguard.py
@@ -10963,6 +10963,7 @@ class FaultTreeApp:
                 "hara_names": getattr(r, 'hara_names', []),
             })
         current_name = self.review_data.name if self.review_data else None
+        repo = SysMLRepository.get_instance()
         data = {
             "top_events": [event.to_dict() for event in self.top_events],
             "fmeas": [
@@ -11038,6 +11039,7 @@ class FaultTreeApp:
             "global_requirements": global_requirements,
             "reviews": reviews,
             "current_review": current_name,
+            "sysml_repository": repo.to_dict(),
         }
         if include_versions:
             data["versions"] = self.versions
@@ -11086,6 +11088,11 @@ class FaultTreeApp:
                     f"Failed to parse JSON file:\n{exc}",
                 )
                 return
+
+        repo_data = data.get("sysml_repository")
+        if repo_data:
+            repo = SysMLRepository.get_instance()
+            repo.from_dict(repo_data)
 
         if "top_events" in data:
             self.top_events = [FaultTreeNode.from_dict(e) for e in data["top_events"]]

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -169,5 +169,16 @@ class RepositoryTests(unittest.TestCase):
         self.assertEqual(len(nd.connections), 1)
         self.assertEqual(nd.connections[0]["conn_type"], "Association")
 
+    def test_to_from_dict(self):
+        diag = self.repo.create_diagram("Use Case Diagram", name="UC")
+        actor = self.repo.create_element("Actor", name="User")
+        self.repo.add_element_to_diagram(diag.diag_id, actor.elem_id)
+        data = self.repo.to_dict()
+        SysMLRepository._instance = None
+        new_repo = SysMLRepository.get_instance()
+        new_repo.from_dict(data)
+        self.assertIn(diag.diag_id, new_repo.diagrams)
+        self.assertIn(actor.elem_id, new_repo.diagrams[diag.diag_id].elements)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- extend `SysMLRepository` with `to_dict`/`from_dict`
- include SysML repository data when exporting models
- reload repository from JSON when loading models
- add regression tests for the new repository helpers

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688313d769f48325a4af5d2e97ce40f4