### PR TITLE
Fix persistent highlight in SysML editor

### DIFF
--- a/architecture.py
+++ b/architecture.py
@@ -138,7 +138,8 @@ class SysMLDiagramWindow(tk.Toplevel):
             if self.start is None:
                 if obj:
                     self.start = obj
-                    self.selected_obj = obj
+                    # Do not highlight objects while adding a connection
+                    self.selected_obj = None
                     self.temp_line_end = (x, y)
                     self.redraw()
             else:
@@ -285,7 +286,8 @@ class SysMLDiagramWindow(tk.Toplevel):
                 ConnectionDialog(self, conn)
         self.start = None
         self.temp_line_end = None
-        self.selected_obj = None
+        if self.current_tool != "Select":
+            self.selected_obj = None
         self.resizing_obj = None
         self.resize_edge = None
         self.redraw()


### PR DESCRIPTION
## Summary
- keep selected SysML objects highlighted after releasing the mouse
- suppress highlighting when using connection tools so objects don't light up

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688319d0cfd08325a4482b047bab74ba