### PR TITLE
Fix missing import for SysMLElement

### DIFF
--- a/architecture.py
+++ b/architecture.py
@@ -3,7 +3,7 @@ from tkinter import ttk, simpledialog, messagebox
 from dataclasses import dataclass, field
 from typing import Dict, List, Tuple
 
-from sysml_repository import SysMLRepository, SysMLDiagram
+from sysml_repository import SysMLRepository, SysMLDiagram, SysMLElement
 
 from sysml_spec import SYSML_PROPERTIES
 from models import global_requirements


### PR DESCRIPTION
## Summary
- import `SysMLElement` in `architecture.py`

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68831ae29b788325aadea9c7e99c47c1