### PR TITLE
Fix unhashable ReliabilityComponent

### DIFF
--- a/models.py
+++ b/models.py
@@ -41,6 +41,10 @@ class ReliabilityComponent:
     is_passive: bool = False
     sub_boms: list = field(default_factory=list)
 
+    def __hash__(self) -> int:
+        """Allow instances to be used as dictionary keys based on identity."""
+        return id(self)
+
 QUALIFICATIONS = [
     "AEC-Q100",
     "AEC-Q101",


### PR DESCRIPTION
## Summary
- add a `__hash__` implementation to `ReliabilityComponent` so instances can be used in dictionaries

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68832de7b4e88325b9385521bdca8758