### PR TITLE
Fix missing helper in architecture

### DIFF
--- a/architecture.py
+++ b/architecture.py
@@ -38,6 +38,14 @@ def _get_next_id() -> int:
     return val
 
 
+def _parse_float(val: str | None, default: float) -> float:
+    """Convert *val* to ``float`` or return ``default`` if conversion fails."""
+    try:
+        return float(val)
+    except (TypeError, ValueError):
+        return default
+
+
 def _find_parent_blocks(repo: SysMLRepository, block_id: str) -> set[str]:
     """Return all blocks that directly use ``block_id`` as a part or are
     associated with it."""


### PR DESCRIPTION
## Summary
- add `_parse_float` to convert property strings to float
- ensure diagrams can parse numeric offsets without error

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68832fa7d788832588c60611af3133e1