### PR TITLE
Fix system boundary label position

### DIFF
--- a/architecture.py
+++ b/architecture.py
@@ -785,13 +785,13 @@ class SysMLDiagramWindow(tk.Toplevel):
             )
             label = obj.properties.get("name", "")
             if label:
-                lx = x - w + 4 * self.zoom
+                lx = x
                 ly = y - h - 4 * self.zoom
                 self.canvas.create_text(
                     lx,
                     ly,
                     text=label,
-                    anchor="sw",
+                    anchor="s",
                     font=self.font,
                 )
         elif obj.obj_type in ("Action Usage", "Action", "Part", "Port"):


### PR DESCRIPTION
## Summary
- display the System Boundary name above the boundary in use case diagrams

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68833484b6d08325979b88dd644f5c4d