### PR TITLE
Remove fit qualification fields from Part properties

### DIFF
--- a/architecture.py
+++ b/architecture.py
@@ -1391,14 +1391,15 @@ class SysMLObjectDialog(simpledialog.Dialog):
             else:
                 prop_row += 1
 
-        # Always display FIT and qualification values if present
-        for prop in ("fit", "qualification"):
-            if prop not in self.entries and self.obj.properties.get(prop, ""):
-                ttk.Label(rel_frame, text=f"{prop}:").grid(row=rel_row, column=0, sticky="e", padx=4, pady=2)
-                var = tk.StringVar(value=self.obj.properties.get(prop, ""))
-                ttk.Entry(rel_frame, textvariable=var, state="readonly").grid(row=rel_row, column=1, padx=4, pady=2)
-                self.entries[prop] = var
-                rel_row += 1
+        # Always display FIT and qualification for blocks if available
+        if self.obj.obj_type == "Block":
+            for prop in ("fit", "qualification"):
+                if prop not in self.entries and self.obj.properties.get(prop, ""):
+                    ttk.Label(rel_frame, text=f"{prop}:").grid(row=rel_row, column=0, sticky="e", padx=4, pady=2)
+                    var = tk.StringVar(value=self.obj.properties.get(prop, ""))
+                    ttk.Entry(rel_frame, textvariable=var, state="readonly").grid(row=rel_row, column=1, padx=4, pady=2)
+                    self.entries[prop] = var
+                    rel_row += 1
 
         repo = SysMLRepository.get_instance()
         link_row = 0

--- a/sysml_spec.py
+++ b/sysml_spec.py
@@ -58,6 +58,6 @@ for prop in ('circuit', 'fit', 'qualification', 'failureModes'):
     if prop not in SYSML_PROPERTIES['BlockUsage']:
         SYSML_PROPERTIES['BlockUsage'].append(prop)
 
-for prop in ('component', 'fit', 'qualification', 'failureModes'):
+for prop in ('component', 'failureModes'):
     if prop not in SYSML_PROPERTIES['PartUsage']:
         SYSML_PROPERTIES['PartUsage'].append(prop)


### PR DESCRIPTION
## Summary
- keep reliability FIT and qualification fields for blocks only
- remove FIT and qualification from `PartUsage` properties

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688335d8b8048325900ea03255837592