### PR TITLE
Prevent ports without parent parts

### DIFF
--- a/tests/test_ports.py
+++ b/tests/test_ports.py
@@ -1,0 +1,18 @@
+import unittest
+from architecture import SysMLObject, remove_orphan_ports
+
+class PortParentTests(unittest.TestCase):
+    def test_remove_orphan_ports(self):
+        part = SysMLObject(1, "Part", 0, 0)
+        good_port = SysMLObject(2, "Port", 0, 0, properties={"parent": "1"})
+        orphan_port = SysMLObject(3, "Port", 0, 0)
+        bad_port = SysMLObject(4, "Port", 0, 0, properties={"parent": "99"})
+        objs = [part, good_port, orphan_port, bad_port]
+        remove_orphan_ports(objs)
+        self.assertIn(part, objs)
+        self.assertIn(good_port, objs)
+        self.assertNotIn(orphan_port, objs)
+        self.assertNotIn(bad_port, objs)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `remove_orphan_ports` helper to strip invalid ports
- skip port creation when no part was clicked
- remove orphan ports whenever diagrams redraw
- test removal of orphan ports

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68833abfc3fc8325913b066e9ab1d1f5