### PR TITLE
Fix blank string handling for reliability calculations

### DIFF
--- a/models.py
+++ b/models.py
@@ -75,8 +75,12 @@ PASSIVE_QUAL_FACTORS = {
 
 
 def safe_float(value, default=0.0):
-    """Convert ``value`` to ``float`` returning ``default`` on error."""
+    """Safely convert ``value`` to ``float`` returning ``default`` on error."""
     try:
+        if isinstance(value, str):
+            value = value.strip()
+            if not value:
+                return default
         return float(value)
     except (TypeError, ValueError):
         return default


### PR DESCRIPTION
## Summary
- guard against empty strings when converting values to float

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688346d34f988325985ecbe25c604a39