### PR TITLE
Fix missing model imports

### DIFF
--- a/AutoSafeguard.py
+++ b/AutoSafeguard.py
@@ -256,6 +256,8 @@ from models import (
     HaraEntry,
     HazopDoc,
     HaraDoc,
+    FI2TCDoc,
+    TC2FIDoc,
     QUALIFICATIONS,
     COMPONENT_ATTR_TEMPLATES,
     RELIABILITY_MODELS,


### PR DESCRIPTION
## Summary
- import `FI2TCDoc` and `TC2FIDoc` in AutoSafeguard

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688347c830648325b866fec9d2211b0b