### PR TITLE
Rename architecture language to AutoML

### DIFF
--- a/AutoSafeguard.py
+++ b/AutoSafeguard.py
@@ -1766,8 +1766,8 @@ class FaultTreeApp:
         architecture_menu.add_command(label="Block Diagram", command=self.open_block_diagram)
         architecture_menu.add_command(label="Internal Block Diagram", command=self.open_internal_block_diagram)
         architecture_menu.add_separator()
-        architecture_menu.add_command(label="Architecture Explorer", command=self.manage_architecture)
-        menubar.add_cascade(label="Architecture", menu=architecture_menu)
+        architecture_menu.add_command(label="AutoML Explorer", command=self.manage_architecture)
+        menubar.add_cascade(label="AutoML", menu=architecture_menu)
 
         hara_menu = tk.Menu(menubar, tearoff=0)
         hara_menu.add_command(label="HAZOP Analysis", command=self.open_hazop_window)
@@ -7337,7 +7337,7 @@ class FaultTreeApp:
             tc2fi_root = tree.insert("", "end", text="TC2FI Analyses", open=True)
             for idx, doc in enumerate(self.tc2fi_docs):
                 tree.insert(tc2fi_root, "end", text=doc.name, tags=("tc2fi", str(idx)))
-            arch_root = tree.insert("", "end", text="Architecture Diagrams", open=True)
+            arch_root = tree.insert("", "end", text="AutoML Diagrams", open=True)
             for idx, diag in enumerate(self.arch_diagrams):
                 name = diag.get('name', f'Diagram {idx+1}')
                 tree.insert(arch_root, "end", text=name, tags=("arch", str(idx)))

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AutoSafeguard Analyzer
 
-This repository contains a graphical fault tree analysis tool. The latest update adds a **Review Toolbox** supporting peer and joint review workflows. The explorer pane now includes an **Analyses** tab listing all FMEAs, FMEDAs, HAZOPs, HARAs and architecture diagrams so they can be opened directly. Architecture objects can now be resized either by editing width and height values or by dragging the red handles that appear when an item is selected. Fork and join bars keep a constant thickness so only their length changes.
+This repository contains a graphical fault tree analysis tool. The latest update adds a **Review Toolbox** supporting peer and joint review workflows. The explorer pane now includes an **Analyses** tab listing all FMEAs, FMEDAs, HAZOPs, HARAs and AutoML diagrams so they can be opened directly. Architecture objects can now be resized either by editing width and height values or by dragging the red handles that appear when an item is selected. Fork and join bars keep a constant thickness so only their length changes.
 
 ## Review Toolbox
 
@@ -69,7 +69,7 @@ Additional datasheet parameters such as diode forward voltage or MOSFET
 `RDS(on)` can be entered when configuring components to better document the
 parts used in the analysis.
 
-### BOM Integration with SysML Diagrams
+### BOM Integration with AutoML Diagrams
 
 Blocks in block diagrams may reference circuits defined in a saved BOM via the
 new **circuit** property while parts reference individual components using the
@@ -77,15 +77,15 @@ new **circuit** property while parts reference individual components using the
 **qualification** and **failureModes** attributes.  Entering values for these
 fields shows them in a *Reliability* compartment for blocks or as additional
 lines beneath parts so FIT rates and qualification information remain visible in
-the architecture model. When editing a block or part you can now pick from
+the AutoML model. When editing a block or part you can now pick from
 drop-down lists containing all circuits or components from saved reliability
 analyses. Selecting an item automatically fills in its FIT rate, qualification
 certificate and any failure modes found in FMEA tables.
 
-### Architecture Diagrams and Safety Analyses
+### AutoML Diagrams and Safety Analyses
 
 Use case, activity, block and internal block diagrams can be created from the
-**Architecture** menu. Diagrams are stored inside the model and appear in the
+**AutoML** menu. Diagrams are stored inside the model and appear in the
 *Analyses* explorer tab so they can be reopened alongside FMEAs and other
 documents. Each object keeps its saved size and properties so layouts remain
 stable when returning to the project.

--- a/architecture.py
+++ b/architecture.py
@@ -12,7 +12,7 @@ from models import global_requirements
 # ---------------------------------------------------------------------------
 # Appearance customization
 # ---------------------------------------------------------------------------
-# Basic fill colors for different SysML object types. This provides a simple
+# Basic fill colors for different AutoML object types. This provides a simple
 # color palette so diagrams appear less bland and more professional.
 OBJECT_COLORS: dict[str, str] = {
     "Actor": "#E0F7FA",
@@ -148,7 +148,7 @@ class DiagramConnection:
 
 
 class SysMLDiagramWindow(tk.Toplevel):
-    """Base window for simple SysML diagrams with zoom and pan support."""
+    """Base window for AutoML diagrams with zoom and pan support."""
 
     def __init__(self, master, title, tools, diagram_id: str | None = None, app=None):
         super().__init__(master)
@@ -1176,7 +1176,7 @@ class SysMLDiagramWindow(tk.Toplevel):
         self.destroy()
 
 class SysMLObjectDialog(simpledialog.Dialog):
-    """Simple dialog for editing SysML object properties."""
+    """Simple dialog for editing AutoML object properties."""
 
     def __init__(self, master, obj: SysMLObject):
         if not hasattr(obj, "requirements"):
@@ -1998,7 +1998,7 @@ class ArchitectureManagerDialog(tk.Toplevel):
     def __init__(self, master, app=None):
         super().__init__(master)
         self.app = app
-        self.title("Architecture Explorer")
+        self.title("AutoML Explorer")
         self.repo = SysMLRepository.get_instance()
         self.geometry("350x400")
         self.tree = ttk.Treeview(self)

--- a/sysml_repository.py
+++ b/sysml_repository.py
@@ -6,7 +6,7 @@ import os
 
 @dataclass
 class SysMLElement:
-    """Basic SysML element stored in the repository."""
+    """Basic AutoML element stored in the repository."""
     elem_id: str
     elem_type: str
     name: str = ""
@@ -37,7 +37,7 @@ class SysMLDiagram:
     connections: List[dict] = field(default_factory=list)
 
 class SysMLRepository:
-    """Singleton repository for all SysML elements and relationships."""
+    """Singleton repository for all AutoML elements and relationships."""
     _instance = None
 
     def __init__(self):


### PR DESCRIPTION
## Summary
- update documentation to refer to *AutoML – Automotive Modeling Language*
- adjust menu labels and tree view text to use AutoML
- update architecture dialog text
- tweak repository and architecture docstrings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68834b879fa08325a5fd8e914032999b